### PR TITLE
[WQ-16] feat: 웹/모바일/테스트용 TokenStore 구현 및 토큰 관리 메서드 추가

### DIFF
--- a/storage/FakeTokenStore.ts
+++ b/storage/FakeTokenStore.ts
@@ -1,1 +1,33 @@
-// 테스트용 가짜 저장소 
+// 테스트용 가짜 저장소
+// 테스트 전용 - 절대 프로덕션 환경에 사용하지 마세요
+import { Token } from '../types';
+import { TokenStore } from './TokenStore.interface';
+
+let memoryToken: Token | null = null;
+
+export const FakeTokenStore: TokenStore = {
+  async saveToken(token: Token): Promise<boolean> {
+    memoryToken = { ...token };
+    return true;
+  },
+  async getToken(): Promise<Token | null> {
+    return memoryToken ? { ...memoryToken } : null;
+  },
+  async removeToken(): Promise<boolean> {
+    // 현재 사용자의 토큰만 제거 (로그아웃 시 사용)
+    memoryToken = null;
+    return true;
+  },
+  async hasToken(): Promise<boolean> {
+    return memoryToken !== null;
+  },
+  async isTokenExpired(): Promise<boolean> {
+    if (!memoryToken || !memoryToken.expiresAt) return false;
+    return Date.now() > memoryToken.expiresAt;
+  },
+  async clear(): Promise<boolean> {
+    // 모든 토큰 관련 데이터를 완전히 정리 (앱 초기화나 데이터 완전 삭제 시 사용)
+    memoryToken = null;
+    return true;
+  },
+}; 

--- a/storage/MobileTokenStore.ts
+++ b/storage/MobileTokenStore.ts
@@ -1,1 +1,66 @@
 // 모바일 환경 저장소 (ex: SecureStore) 
+// TODO: SecureStore 연동 예정
+import { Token } from '../types';
+import { TokenStore } from './TokenStore.interface';
+// 실제 환경에서는 'expo-secure-store' 또는 유사 패키지를 import
+// import * as SecureStore from 'expo-secure-store';
+
+export const MobileTokenStore: TokenStore = {
+  async saveToken(token: Token): Promise<boolean> {
+    try {
+      // await SecureStore.setItemAsync('accessToken', token.accessToken);
+      // if (token.refreshToken) await SecureStore.setItemAsync('refreshToken', token.refreshToken);
+      // if (token.expiresAt) await SecureStore.setItemAsync('expiresAt', token.expiresAt.toString());
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+  async getToken(): Promise<Token | null> {
+    // const accessToken = await SecureStore.getItemAsync('accessToken');
+    // if (!accessToken) return null;
+    // const refreshToken = await SecureStore.getItemAsync('refreshToken') || undefined;
+    // const expiresAtStr = await SecureStore.getItemAsync('expiresAt');
+    // const expiresAt = expiresAtStr ? Number(expiresAtStr) : undefined;
+    // return { accessToken, refreshToken, expiresAt };
+    return null;
+  },
+  async removeToken(): Promise<boolean> {
+    // 현재 사용자의 토큰만 제거 (로그아웃 시 사용)
+    try {
+      // await SecureStore.deleteItemAsync('accessToken');
+      // await SecureStore.deleteItemAsync('refreshToken');
+      // await SecureStore.deleteItemAsync('expiresAt');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+  async hasToken(): Promise<boolean> {
+    // const accessToken = await SecureStore.getItemAsync('accessToken');
+    // return accessToken !== null;
+    return false;
+  },
+  async isTokenExpired(): Promise<boolean> {
+    // const expiresAtStr = await SecureStore.getItemAsync('expiresAt');
+    // if (!expiresAtStr) return false;
+    // const expiresAt = Number(expiresAtStr);
+    // return Date.now() > expiresAt;
+    return false;
+  },
+  async clear(): Promise<boolean> {
+    // 모든 토큰 관련 데이터를 완전히 정리 (앱 초기화나 데이터 완전 삭제 시 사용)
+    try {
+      // await SecureStore.deleteItemAsync('accessToken');
+      // await SecureStore.deleteItemAsync('refreshToken');
+      // await SecureStore.deleteItemAsync('expiresAt');
+      // 추가로 다른 토큰 관련 키들도 모두 삭제
+      // await SecureStore.deleteItemAsync('userId');
+      // await SecureStore.deleteItemAsync('userInfo');
+      // await SecureStore.deleteItemAsync('lastLoginTime');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+}; 

--- a/storage/WebTokenStore.ts
+++ b/storage/WebTokenStore.ts
@@ -1,1 +1,74 @@
 // 웹 환경 저장소 (ex: localStorage) 
+import { Token } from '../types';
+import { TokenStore } from './TokenStore.interface';
+
+export const WebTokenStore: TokenStore = {
+  async saveToken(token: Token): Promise<boolean> {
+    try {
+      localStorage.setItem('accessToken', token.accessToken);
+      if (token.refreshToken) {
+        localStorage.setItem('refreshToken', token.refreshToken);
+      } else {
+        localStorage.removeItem('refreshToken');
+      }
+      if (token.expiresAt) {
+        localStorage.setItem('expiresAt', token.expiresAt.toString());
+      } else {
+        localStorage.removeItem('expiresAt');
+      }
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+
+  async getToken(): Promise<Token | null> {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) return null;
+    const refreshToken = localStorage.getItem('refreshToken') || undefined;
+    const expiresAtStr = localStorage.getItem('expiresAt');
+    const expiresAt = expiresAtStr ? Number(expiresAtStr) : undefined;
+    return { accessToken, refreshToken, expiresAt };
+  },
+
+  async removeToken(): Promise<boolean> {
+    // 현재 사용자의 토큰만 제거 (로그아웃 시 사용)
+    try {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      localStorage.removeItem('expiresAt');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+
+  async hasToken(): Promise<boolean> {
+    return localStorage.getItem('accessToken') !== null;
+  },
+
+  async isTokenExpired(): Promise<boolean> {
+    const expiresAtStr = localStorage.getItem('expiresAt');
+    if (!expiresAtStr) return false;
+    const expiresAt = Number(expiresAtStr);
+    return Date.now() > expiresAt;
+  },
+
+  async clear(): Promise<boolean> {
+    // 모든 토큰 관련 데이터를 완전히 정리 (앱 초기화나 데이터 완전 삭제 시 사용)
+    try {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      localStorage.removeItem('expiresAt');
+      // 추가로 다른 토큰 관련 키들도 모두 삭제
+      localStorage.removeItem('userId');
+      localStorage.removeItem('userInfo');
+      localStorage.removeItem('lastLoginTime');
+      localStorage.removeItem('authProvider');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+};
+  


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close [WQ-16]

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- WebTokenStore, MobileTokenStore, FakeTokenStore 세 가지 토큰 저장소 구현
    - 각각 웹(localStorage), 모바일(SecureStore 예정), 테스트(메모리) 환경에 맞게 설계
- TokenStore 인터페이스에 따라 토큰 저장, 조회, 삭제, 만료 확인, 전체 삭제(clear) 기능 제공
- MobileTokenStore는 실제 SecureStore 연동은 추후 구현 예정(현재 주석 처리)
- 코드 내 주석을 통해 각 메서드의 용도와 차이점 명확히 설명

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


[WQ-16]: https://growgrammers.atlassian.net/browse/WQ-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ