### PR TITLE
[WQ-34] refactor: provider API 호출 로직 외부 모듈로 분리 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,32 @@
 
 ```
 auth-core/
+├── api/                          # API 호출 로직 분리
+│   ├── authApi.ts                # 인증 관련 API 함수들
+│   ├── types.ts                  # API 모듈 공통 타입
+│   └── index.ts                  # API 모듈 진입점
+│
 ├── providers/                     # 로그인 방식 전략 모음 (Strategy)
-│   ├── AuthProvider.ts            # 공통 인터페이스
-│   ├── EmailAuthProvider.ts       # 이메일 로그인 구현
-│   ├── GoogleAuthProvider.ts      # 구글 로그인 구현
-│   └── KakaoAuthProvider.ts       # 카카오 로그인 구현 (예정)
+│   ├── interfaces/                # 인터페이스 정의
+│   │   └── AuthProvider.ts       # 공통 인터페이스
+│   ├── base/                     # 기본 클래스
+│   │   └── BaseAuthProvider.ts   # 공통 로직 추상 클래스
+│   ├── implementations/           # 구체적 구현체
+│   │   ├── EmailAuthProvider.ts  # 이메일 로그인 구현
+│   │   └── GoogleAuthProvider.ts # 구글 로그인 구현
+│   └── index.ts                  # Provider 모듈 진입점
 │
 ├── factories/                     # 전략 객체 생성 책임 (Factory)
-│   └── AuthProviderFactory.ts     # 문자열 or config 기반으로 전략 생성
+│   ├── AuthProviderFactory.ts    # 문자열 or config 기반으로 전략 생성
+│   ├── TokenStoreFactory.ts      # 토큰 저장소 팩토리
+│   └── AuthManagerFactory.ts     # AuthManager 팩토리
 │
 ├── storage/                       # 토큰 저장 전략
-│   ├── TokenStore.interface.ts    # 저장 전략 인터페이스
-│   ├── WebTokenStore.ts           # 웹 환경 저장소 (ex: localStorage)
-│   ├── MobileTokenStore.ts        # 모바일 환경 저장소 (ex: SecureStore)
-│   └── FakeTokenStore.ts          # 테스트용 가짜 저장소
+│   ├── TokenStore.interface.ts   # 저장 전략 인터페이스
+│   ├── WebTokenStore.ts          # 웹 환경 저장소 (ex: localStorage)
+│   ├── MobileTokenStore.ts       # 모바일 환경 저장소 (ex: SecureStore)
+│   ├── FakeTokenStore.ts         # 테스트용 가짜 저장소
+│   └── index.ts                  # Storage 모듈 진입점
 │
 ├── AuthManager.ts                 # 전략들을 주입받아 로그인 흐름 제어
 ├── types.ts                       # 공통 타입 모음
@@ -31,6 +43,7 @@ auth-core/
 - **Strategy Pattern**: 다양한 로그인 방식을 전략으로 구현
 - **Factory Pattern**: 설정에 따라 적절한 인증 제공자 생성
 - **Dependency Injection**: 토큰 저장소와 인증 제공자를 주입받아 사용
+- **Single Responsibility Principle (SRP)**: API 호출 로직을 외부 모듈로 분리하여 각 클래스의 책임을 명확히 분리
 
 ## 사용 예정 환경
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ auth-core/
 - **Strategy Pattern**: 다양한 로그인 방식을 전략으로 구현
 - **Factory Pattern**: 설정에 따라 적절한 인증 제공자 생성
 - **Dependency Injection**: 토큰 저장소와 인증 제공자를 주입받아 사용
-- **Single Responsibility Principle (SRP)**: API 호출 로직을 외부 모듈로 분리하여 각 클래스의 책임을 명확히 분리
 
 ## 사용 예정 환경
 

--- a/api/googleAuthApi.ts
+++ b/api/googleAuthApi.ts
@@ -1,0 +1,84 @@
+// Google OAuth 관련 API 함수들 (향후 구현 예정)
+import { ApiConfig, ApiResponse, Token, UserInfo } from '../types';
+import { 
+  LoginRequest, 
+  LogoutRequest, 
+  RefreshTokenRequest
+} from '../providers/interfaces/AuthProvider';
+
+/**
+ * Google OAuth 로그인 (향후 구현)
+ */
+export async function loginByGoogle(
+  config: ApiConfig,
+  request: LoginRequest
+): Promise<ApiResponse<{ token: Token; userInfo: UserInfo }>> {
+  // TODO: Google OAuth 구현
+  return {
+    success: false,
+    error: 'GoogleAuthProvider는 아직 구현되지 않았습니다.',
+    errorCode: 'NOT_IMPLEMENTED'
+  };
+}
+
+/**
+ * Google OAuth 로그아웃 (향후 구현)
+ */
+export async function logoutByGoogle(
+  config: ApiConfig,
+  request: LogoutRequest
+): Promise<ApiResponse> {
+  // TODO: Google OAuth 구현
+  return {
+    success: false,
+    error: 'GoogleAuthProvider는 아직 구현되지 않았습니다.',
+    errorCode: 'NOT_IMPLEMENTED'
+  };
+}
+
+/**
+ * Google OAuth 토큰 갱신 (향후 구현)
+ */
+export async function refreshTokenByGoogle(
+  config: ApiConfig,
+  request: RefreshTokenRequest
+): Promise<ApiResponse<{ token: Token }>> {
+  // TODO: Google OAuth 구현
+  return {
+    success: false,
+    error: 'GoogleAuthProvider는 아직 구현되지 않았습니다.',
+    errorCode: 'NOT_IMPLEMENTED'
+  };
+}
+
+/**
+ * Google OAuth 토큰 검증 (향후 구현)
+ */
+export async function validateTokenByGoogle(
+  config: ApiConfig,
+  token: Token
+): Promise<boolean> {
+  // TODO: Google OAuth 구현
+  return false;
+}
+
+/**
+ * Google OAuth 사용자 정보 조회 (향후 구현)
+ */
+export async function getUserInfoByGoogle(
+  config: ApiConfig,
+  token: Token
+): Promise<UserInfo | null> {
+  // TODO: Google OAuth 구현
+  return null;
+}
+
+/**
+ * Google OAuth 서비스 가용성 확인 (향후 구현)
+ */
+export async function checkGoogleServiceAvailability(
+  config: ApiConfig
+): Promise<boolean> {
+  // TODO: Google OAuth 구현
+  return false;
+} 

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,34 @@
+// API 모듈 메인 인덱스 파일
+// 모든 API 함수들을 다시 export하여 기존 import 구조를 유지합니다.
+
+// 공통 유틸리티 함수들
+export {
+  makeRequest,
+  makeRequestWithRetry,
+  handleHttpResponse,
+  createToken,
+  createUserInfo
+} from './utils/httpUtils';
+
+// 이메일 인증 API 함수들
+export {
+  requestEmailVerification,
+  loginByEmail,
+  logoutByEmail,
+  refreshTokenByEmail,
+  validateTokenByEmail,
+  getUserInfoByEmail,
+  checkEmailServiceAvailability
+} from './emailAuthApi';
+
+// Google OAuth API 함수들
+export {
+  loginByGoogle,
+  logoutByGoogle,
+  refreshTokenByGoogle,
+  validateTokenByGoogle,
+  getUserInfoByGoogle,
+  checkGoogleServiceAvailability
+} from './googleAuthApi';
+
+// 타입들은 루트 types.ts에서 관리하므로 여기서는 export하지 않음 

--- a/api/utils/index.ts
+++ b/api/utils/index.ts
@@ -1,0 +1,2 @@
+// HTTP 유틸리티 함수들 export
+export * from './httpUtils'; 

--- a/index.ts
+++ b/index.ts
@@ -14,8 +14,7 @@ export {
   LogoutRequest,
   LogoutResponse,
   RefreshTokenRequest,
-  RefreshTokenResponse,
-  RequestOptions
+  RefreshTokenResponse
 } from './providers';
 
 // 구현체들
@@ -34,4 +33,7 @@ export { createTokenStore, TokenStoreType } from './factories/TokenStoreFactory'
 export { 
   createAuthManager, 
   createAuthManagerFromInstances
-} from './factories/AuthManagerFactory'; 
+} from './factories/AuthManagerFactory';
+
+// API 모듈
+export * from './api'; 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "auth-core",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  }
+}

--- a/providers/base/BaseAuthProvider.ts
+++ b/providers/base/BaseAuthProvider.ts
@@ -1,4 +1,4 @@
-// 기본 인증 제공자 추상 클래스 : 중복되는 공통 로직을 추출한 추상 클래스
+// 기본 인증 제공자 추상 클래스 : API 호출 로직이 외부 모듈로 분리된 버전
 import { Token, UserInfo, BaseResponse } from '../../types';
 import { 
   AuthProvider, 
@@ -10,64 +10,12 @@ import {
   LogoutRequest, 
   LogoutResponse,
   RefreshTokenRequest,
-  RefreshTokenResponse,
-  RequestOptions
+  RefreshTokenResponse
 } from '../interfaces/AuthProvider';
 
 export abstract class BaseAuthProvider implements AuthProvider {
   abstract readonly providerName: AuthProvider['providerName'];
   abstract readonly config: AuthProviderConfig;
-
-  /**
-   * 공통 HTTP 요청 메서드
-   */
-  protected async makeRequest(endpoint: string, options: RequestOptions): Promise<Response> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), options.timeout || this.config.timeout || 10000);
-
-    try {
-      const response = await fetch(`${this.config.apiBaseUrl}${endpoint}`, {
-        method: options.method,
-        headers: {
-          'Content-Type': 'application/json',
-          ...options.headers,
-        },
-        body: options.body ? JSON.stringify(options.body) : undefined,
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-      return response;
-    } catch (error) {
-      clearTimeout(timeoutId);
-      throw error;
-    }
-  }
-
-  /**
-   * 재시도 로직이 포함된 HTTP 요청
-   */
-  protected async makeRequestWithRetry(endpoint: string, options: RequestOptions): Promise<Response> {
-    const maxRetries = this.config.retryCount || 3;
-    let lastError: Error;
-
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        return await this.makeRequest(endpoint, options);
-      } catch (error) {
-        lastError = error as Error;
-        
-        if (attempt === maxRetries) {
-          throw lastError;
-        }
-        
-        // 지수 백오프: 1초, 2초, 4초...
-        await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt - 1) * 1000));
-      }
-    }
-
-    throw lastError!;
-  }
 
   /**
    * 공통 응답 생성 메서드 - 제네릭을 사용하여 타입 안전성 확보
@@ -84,58 +32,6 @@ export abstract class BaseAuthProvider implements AuthProvider {
       errorCode,
       ...additionalData
     } as T;
-  }
-
-  /**
-   * 공통 HTTP 응답 처리 - 성공/실패 판단 및 에러 응답 생성
-   */
-  protected async handleHttpResponse<T extends BaseResponse>(
-    response: Response, 
-    errorMessage: string,
-    createErrorResponse: (error: string, errorCode?: string) => T
-  ): Promise<T> {
-    if (!response.ok) {
-      try {
-        const data = await response.json();
-        return createErrorResponse(
-          data.message || errorMessage,
-          data.errorCode
-        );
-      } catch {
-        return createErrorResponse(errorMessage, 'UNKNOWN_ERROR');
-      }
-    }
-    
-    throw new Error('Response is ok but no success handler provided');
-  }
-
-  /**
-   * 공통 HTTP 응답 처리 - 성공 시 데이터 반환
-   */
-  protected async handleHttpResponseWithData<T extends BaseResponse>(
-    response: Response,
-    errorMessage: string,
-    createErrorResponse: (error: string, errorCode?: string) => T,
-    successHandler: (data: any) => T
-  ): Promise<T> {
-    if (!response.ok) {
-      try {
-        const data = await response.json();
-        return createErrorResponse(
-          data.message || errorMessage,
-          data.errorCode
-        );
-      } catch {
-        return createErrorResponse(errorMessage, 'UNKNOWN_ERROR');
-      }
-    }
-
-    try {
-      const data = await response.json();
-      return successHandler(data);
-    } catch (error) {
-      return createErrorResponse('응답 데이터 파싱에 실패했습니다.', 'PARSE_ERROR');
-    }
   }
 
   // 추상 메서드들 - 하위 클래스에서 구현

--- a/providers/implementations/EmailAuthProvider.ts
+++ b/providers/implementations/EmailAuthProvider.ts
@@ -1,4 +1,4 @@
-// 이메일 로그인 구현 
+// 이메일 로그인 구현 - API 호출 로직이 외부 모듈로 분리된 버전
 import { Token, UserInfo } from '../../types';
 import { 
   AuthProviderConfig,
@@ -13,6 +13,15 @@ import {
   EmailVerificationResponse
 } from '../interfaces/AuthProvider';
 import { BaseAuthProvider } from '../base/BaseAuthProvider';
+import {
+  loginByEmail,
+  logoutByEmail,
+  refreshTokenByEmail,
+  validateTokenByEmail,
+  getUserInfoByEmail,
+  requestEmailVerification,
+  checkEmailServiceAvailability
+} from '../../api/';
 
 export class EmailAuthProvider extends BaseAuthProvider {
   readonly providerName = 'email' as const;
@@ -23,202 +32,81 @@ export class EmailAuthProvider extends BaseAuthProvider {
     this.config = config;
   }
 
-  private createToken(data: { accessToken: string; refreshToken: string; expiresAt?: number }): Token {
-    return {
-      accessToken: data.accessToken,
-      refreshToken: data.refreshToken,
-      expiresAt: data.expiresAt ? Date.now() + data.expiresAt * 1000 : undefined
-    };
-  }
-
   async login(request: LoginRequest): Promise<LoginResponse> {
-    try {
-      // 타입 가드로 이메일 로그인 요청인지 확인
-      if (request.provider !== 'email') {
-        return this.createResponse<LoginResponse>(
-          false,
-          '잘못된 인증 제공자입니다.',
-          'INVALID_PROVIDER'
-        );
-      }
-
-      const emailRequest = request as EmailLoginRequest;
-
-      // 이메일 로그인 검증
-      if (!emailRequest.email || !emailRequest.verificationCode) {
-        return this.createResponse<LoginResponse>(
-          false,
-          '이메일과 인증코드가 필요합니다.',
-          'INVALID_CREDENTIALS'
-        );
-      }
-
-      // API 호출 (공통 HTTP 로직 사용)
-      const response = await this.makeRequestWithRetry('/auth/login', {
-        method: 'POST',
-        body: {
-          email: emailRequest.email,
-          verificationCode: emailRequest.verificationCode,
-          rememberMe: emailRequest.rememberMe
-        },
-      });
-
-      return this.handleHttpResponseWithData(
-        response,
-        '로그인에 실패했습니다.',
-        (error, errorCode) => this.createResponse<LoginResponse>(false, error, errorCode),
-        (data) => {
-          const token: Token = this.createToken(data);
-          const userInfo: UserInfo = {
-            id: data.user.id,
-            email: data.user.email,
-            name: data.user.name,
-            provider: 'email'
-          };
-          return this.createResponse<LoginResponse>(true, undefined, undefined, { token, userInfo });
-        }
-      );
-
-    } catch (error) {
+    const apiResponse = await loginByEmail(this.config, request);
+    
+    if (!apiResponse.success) {
       return this.createResponse<LoginResponse>(
         false,
-        '네트워크 오류가 발생했습니다.',
-        'NETWORK_ERROR'
+        apiResponse.error,
+        apiResponse.errorCode
       );
     }
+
+    return this.createResponse<LoginResponse>(
+      true,
+      undefined,
+      undefined,
+      apiResponse.data
+    );
   }
 
   async logout(request: LogoutRequest): Promise<LogoutResponse> {
-    try {
-      if (!request.token?.accessToken) {
-        return this.createResponse<LogoutResponse>(false, '토큰이 필요합니다.');
-      }
-
-      // 서버에 로그아웃 요청 (공통 HTTP 로직 사용)
-      const response = await this.makeRequestWithRetry('/auth/logout', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${request.token.accessToken}`,
-        },
-      });
-
-      return this.handleHttpResponse(
-        response,
-        '로그아웃에 실패했습니다.',
-        (error, errorCode) => this.createResponse<LogoutResponse>(false, error, errorCode)
+    const apiResponse = await logoutByEmail(this.config, request);
+    
+    if (!apiResponse.success) {
+      return this.createResponse<LogoutResponse>(
+        false,
+        apiResponse.error,
+        apiResponse.errorCode
       );
-
-    } catch (error) {
-      return this.createResponse<LogoutResponse>(false, '네트워크 오류가 발생했습니다.');
     }
+
+    return this.createResponse<LogoutResponse>(true);
   }
 
   async refreshToken(request: RefreshTokenRequest): Promise<RefreshTokenResponse> {
-    try {
-      const response = await this.makeRequestWithRetry('/auth/refresh', {
-        method: 'POST',
-        body: {
-          refreshToken: request.refreshToken
-        },
-      });
-
-      return this.handleHttpResponseWithData(
-        response,
-        '토큰 갱신에 실패했습니다.',
-        (error, errorCode) => this.createResponse<RefreshTokenResponse>(false, error, errorCode),
-        (data) => {
-          const token: Token = this.createToken(data);
-          return this.createResponse<RefreshTokenResponse>(true, undefined, undefined, { token });
-        }
+    const apiResponse = await refreshTokenByEmail(this.config, request);
+    
+    if (!apiResponse.success) {
+      return this.createResponse<RefreshTokenResponse>(
+        false,
+        apiResponse.error,
+        apiResponse.errorCode
       );
-
-    } catch (error) {
-      return this.createResponse<RefreshTokenResponse>(false, '네트워크 오류가 발생했습니다.');
     }
+
+    return this.createResponse<RefreshTokenResponse>(
+      true,
+      undefined,
+      undefined,
+      apiResponse.data
+    );
   }
 
   async validateToken(token: Token): Promise<boolean> {
-    try {
-      const response = await this.makeRequest('/auth/validate', {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${token.accessToken}`,
-        },
-      });
-
-      return response.ok;
-    } catch (error) {
-      return false;
-    }
+    return validateTokenByEmail(this.config, token);
   }
 
   async getUserInfo(token: Token): Promise<UserInfo | null> {
-    try {
-      const response = await this.makeRequest('/auth/me', {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${token.accessToken}`,
-        },
-      });
-
-      if (!response.ok) {
-        return null;
-      }
-
-      const data = await response.json();
-
-      return {
-        id: data.id,
-        email: data.email,
-        name: data.name,
-        provider: 'email'
-      };
-
-    } catch (error) {
-      return null;
-    }
+    return getUserInfoByEmail(this.config, token);
   }
 
   async requestEmailVerification(request: EmailVerificationRequest): Promise<EmailVerificationResponse> {
-    try {
-      if (!request.email) {
-        return this.createResponse<EmailVerificationResponse>(
-          false,
-          '이메일이 필요합니다.',
-          'INVALID_EMAIL'
-        );
-      }
-
-      const response = await this.makeRequestWithRetry('/auth/request-verification', {
-        method: 'POST',
-        body: {
-          email: request.email
-        },
-      });
-
-      return this.handleHttpResponse(
-        response,
-        '인증번호 요청에 실패했습니다.',
-        (error, errorCode) => this.createResponse<EmailVerificationResponse>(false, error, errorCode)
-      );
-
-    } catch (error) {
+    const apiResponse = await requestEmailVerification(this.config, request);
+    
+    if (!apiResponse.success) {
       return this.createResponse<EmailVerificationResponse>(
         false,
-        '네트워크 오류가 발생했습니다.',
-        'NETWORK_ERROR'
+        apiResponse.error,
+        apiResponse.errorCode
       );
     }
+
+    return this.createResponse<EmailVerificationResponse>(true);
   }
 
   async isAvailable(): Promise<boolean> {
-    try {
-      const response = await this.makeRequest('/health', {
-        method: 'GET',
-      });
-      return response.ok;
-    } catch (error) {
-      return false;
-    }
+    return checkEmailServiceAvailability(this.config);
   }
 } 

--- a/providers/implementations/GoogleAuthProvider.ts
+++ b/providers/implementations/GoogleAuthProvider.ts
@@ -1,12 +1,15 @@
-// 구글 로그인 구현 (추후 구현 예정)
-// TODO: Google OAuth 2.0 구현
-// - OAuth 인증 코드 교환
-// - Google 사용자 정보 조회
-// - 서버 토큰 발급
-
+// 구글 로그인 구현 - API 호출 로직이 외부 모듈로 분리된 버전
 import { AuthProviderConfig, LoginRequest, LoginResponse, LogoutRequest, LogoutResponse, RefreshTokenRequest, RefreshTokenResponse, EmailVerificationRequest, EmailVerificationResponse } from '../interfaces/AuthProvider';
 import { BaseAuthProvider } from '../base/BaseAuthProvider';
-import { Token, UserInfo, BaseResponse } from '../../types';
+import { Token, UserInfo } from '../../types';
+import {
+  loginByGoogle,
+  logoutByGoogle,
+  refreshTokenByGoogle,
+  validateTokenByGoogle,
+  getUserInfoByGoogle,
+  checkGoogleServiceAvailability
+} from '../../api';
 
 export class GoogleAuthProvider extends BaseAuthProvider {
   readonly providerName = 'google' as const;
@@ -27,44 +30,66 @@ export class GoogleAuthProvider extends BaseAuthProvider {
   }
 
   async login(request: LoginRequest): Promise<LoginResponse> {
-    // TODO: OAuth 인증 코드를 받아서 토큰으로 교환하는 로직 구현
+    const apiResponse = await loginByGoogle(this.config, request);
+    
+    if (!apiResponse.success) {
+      return this.createResponse<LoginResponse>(
+        false,
+        apiResponse.error,
+        apiResponse.errorCode
+      );
+    }
+
     return this.createResponse<LoginResponse>(
-      false,
-      'GoogleAuthProvider는 아직 구현되지 않았습니다.',
-      'NOT_IMPLEMENTED'
+      true,
+      undefined,
+      undefined,
+      apiResponse.data
     );
   }
 
   async logout(request: LogoutRequest): Promise<LogoutResponse> {
-    // TODO: Google OAuth 로그아웃 구현
-    return this.createResponse<LogoutResponse>(
-      false,
-      'GoogleAuthProvider는 아직 구현되지 않았습니다.',
-      'NOT_IMPLEMENTED'
-    );
+    const apiResponse = await logoutByGoogle(this.config, request);
+    
+    if (!apiResponse.success) {
+      return this.createResponse<LogoutResponse>(
+        false,
+        apiResponse.error,
+        apiResponse.errorCode
+      );
+    }
+
+    return this.createResponse<LogoutResponse>(true);
   }
 
   async refreshToken(request: RefreshTokenRequest): Promise<RefreshTokenResponse> {
-    // TODO: Google OAuth 토큰 갱신 구현
+    const apiResponse = await refreshTokenByGoogle(this.config, request);
+    
+    if (!apiResponse.success) {
+      return this.createResponse<RefreshTokenResponse>(
+        false,
+        apiResponse.error,
+        apiResponse.errorCode
+      );
+    }
+
     return this.createResponse<RefreshTokenResponse>(
-      false,
-      'GoogleAuthProvider는 아직 구현되지 않았습니다.',
-      'NOT_IMPLEMENTED'
+      true,
+      undefined,
+      undefined,
+      apiResponse.data
     );
   }
 
   async validateToken(token: Token): Promise<boolean> {
-    // TODO: Google OAuth 토큰 검증 구현
-    return false;
+    return validateTokenByGoogle(this.config, token);
   }
 
   async getUserInfo(token: Token): Promise<UserInfo | null> {
-    // TODO: Google OAuth 사용자 정보 조회 구현
-    return null;
+    return getUserInfoByGoogle(this.config, token);
   }
 
   async isAvailable(): Promise<boolean> {
-    // TODO: Google OAuth 서비스 가용성 확인
-    return false;
+    return checkGoogleServiceAvailability(this.config);
   }
 }

--- a/providers/interfaces/AuthProvider.ts
+++ b/providers/interfaces/AuthProvider.ts
@@ -73,18 +73,6 @@ export interface RefreshTokenResponse {
   error?: string;
 }
 
-// HTTP 요청 옵션
-export interface RequestOptions {
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-  headers?: Record<string, string>;
-  // 요청 본문 - 다양한 형태의 데이터를 지원
-  // Record<string, unknown>: JSON 객체 (로그인, 토큰 갱신 등)
-  // string: 문자열 데이터
-  // FormData: 파일 업로드 등 멀티파트 데이터
-  body?: Record<string, unknown> | string | FormData;
-  timeout?: number;
-}
-
 // 인증 제공자 인터페이스
 export interface AuthProvider {
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["es2020", "dom"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/types.ts
+++ b/types.ts
@@ -32,4 +32,34 @@ export interface BaseRequest {
   provider: AuthProviderType;
   rememberMe?: boolean;
 }
+
+// API 모듈 공통 타입 정의
+export interface ApiConfig {
+  apiBaseUrl: string;
+  timeout?: number;
+  retryCount?: number;
+}
+
+export interface RequestOptions {
+  method: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  timeout?: number;
+}
+
+// 성공 응답 타입
+export interface ApiSuccessResponse<T = unknown> {
+  success: true;
+  data: T;
+}
+
+// 실패 응답 타입
+export interface ApiErrorResponse {
+  success: false;
+  error: string;
+  errorCode?: string;
+}
+
+// 통합 API 응답 타입
+export type ApiResponse<T = unknown> = ApiSuccessResponse<T> | ApiErrorResponse;
   


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close #Issue number


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


- 공통 유틸 및 타입 정의
    -공통 HTTP 유틸리티 함수 추가 (makeRequestWithRetry, handleAPIResponse 등)
    -API 요청에 사용될 공통 타입 정의
- 인증 요청 API 함수 정리
    -이메일 인증 관련 API 함수 구현 (요청, 코드검증, 토큰발급 등)
- 구조 리팩토링
    - 인증 제공자별 API 호출 로직 외부 모듈로 분리
    - API 모듈 내 인덱스 통합 및 유틸 export 구조 정비
    - API 호출 방식의 중복 제거 및 통일된 접근 방식 제공
## 📷 스크린샷

> 이미지


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

api 요청에 해당하는 기능을 따로 빼서 모듈화해서 단일책임원칙을 지키려고 했으나.. 작업을 하고 보니 auth-core라는 공통모듈에 너무 플랫폼 의존성 코드가 포함된게 아닌가 하는 생각이 들어서 API 엔드포인트 설정화하는 방식으로 추후 리팩토링 하려고 합니다!! (auth-core에는 순수 비즈니스 로직만 남도록!!)
- 토큰 관리 로직만 남기고 토큰 저장 전략 (localStorage,SecureStorage) 은 플랫폼별 모듈로 이동시키기
- HTTP 클라이언트 구현체도 웹프론트 모듈로 이동시키고, 인터페이스만 유지하기
- 하드코딩된 API엔드포인트를 설정객체로 변경, 환경별 API 설정분리하기


### 📌 PR 진행 시 참고사항

- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)