### PR TITLE
[WQ-35] refactor: OAuth 인증 전략에서 불필요한 메서드 구현 제거

### DIFF
--- a/providers/base/BaseAuthProvider.ts
+++ b/providers/base/BaseAuthProvider.ts
@@ -1,22 +1,7 @@
-// 기본 인증 제공자 추상 클래스 : API 호출 로직이 외부 모듈로 분리된 버전
-import { Token, UserInfo, BaseResponse } from '../../types';
-import { 
-  AuthProvider, 
-  AuthProviderConfig, 
-  EmailVerificationRequest,
-  EmailVerificationResponse,
-  LoginRequest, 
-  LoginResponse, 
-  LogoutRequest, 
-  LogoutResponse,
-  RefreshTokenRequest,
-  RefreshTokenResponse
-} from '../interfaces/AuthProvider';
+// 기본 인증 제공자 유틸리티 클래스 - 공통 응답 생성 메서드 제공
+import { BaseResponse } from '../../types';
 
-export abstract class BaseAuthProvider implements AuthProvider {
-  abstract readonly providerName: AuthProvider['providerName'];
-  abstract readonly config: AuthProviderConfig;
-
+export abstract class BaseAuthProvider {
   /**
    * 공통 응답 생성 메서드 - 제네릭을 사용하여 타입 안전성 확보
    */
@@ -33,13 +18,4 @@ export abstract class BaseAuthProvider implements AuthProvider {
       ...additionalData
     } as T;
   }
-
-  // 추상 메서드들 - 하위 클래스에서 구현
-  abstract requestEmailVerification(request: EmailVerificationRequest): Promise<EmailVerificationResponse>;
-  abstract login(request: LoginRequest): Promise<LoginResponse>;
-  abstract logout(request: LogoutRequest): Promise<LogoutResponse>;
-  abstract refreshToken(request: RefreshTokenRequest): Promise<RefreshTokenResponse>;
-  abstract validateToken(token: Token): Promise<boolean>;
-  abstract getUserInfo(token: Token): Promise<UserInfo | null>;
-  abstract isAvailable(): Promise<boolean>;
 } 

--- a/providers/implementations/EmailAuthProvider.ts
+++ b/providers/implementations/EmailAuthProvider.ts
@@ -1,5 +1,5 @@
 // 이메일 로그인 구현 - API 호출 로직이 외부 모듈로 분리된 버전
-import { Token, UserInfo } from '../../types';
+import { Token, UserInfo, BaseResponse } from '../../types';
 import { 
   AuthProviderConfig,
   LoginRequest, 
@@ -12,7 +12,7 @@ import {
   EmailVerificationRequest,
   EmailVerificationResponse
 } from '../interfaces/AuthProvider';
-import { BaseAuthProvider } from '../base/BaseAuthProvider';
+import { ILoginProvider, IEmailVerifiable } from '../interfaces';
 import {
   loginByEmail,
   logoutByEmail,
@@ -23,13 +23,29 @@ import {
   checkEmailServiceAvailability
 } from '../../api/';
 
-export class EmailAuthProvider extends BaseAuthProvider {
+export class EmailAuthProvider implements ILoginProvider, IEmailVerifiable {
   readonly providerName = 'email' as const;
   readonly config: AuthProviderConfig;
   
   constructor(config: AuthProviderConfig) {
-    super();
     this.config = config;
+  }
+
+  /**
+   * 공통 응답 생성 메서드 - 제네릭을 사용하여 타입 안전성 확보
+   */
+  protected createResponse<T extends BaseResponse>(
+    success: boolean, 
+    error?: string, 
+    errorCode?: string,
+    additionalData?: Partial<T>
+  ): T {
+    return {
+      success,
+      error,
+      errorCode,
+      ...additionalData
+    } as T;
   }
 
   async login(request: LoginRequest): Promise<LoginResponse> {

--- a/providers/implementations/GoogleAuthProvider.ts
+++ b/providers/implementations/GoogleAuthProvider.ts
@@ -1,7 +1,7 @@
 // 구글 로그인 구현 - API 호출 로직이 외부 모듈로 분리된 버전
-import { AuthProviderConfig, LoginRequest, LoginResponse, LogoutRequest, LogoutResponse, RefreshTokenRequest, RefreshTokenResponse, EmailVerificationRequest, EmailVerificationResponse } from '../interfaces/AuthProvider';
-import { BaseAuthProvider } from '../base/BaseAuthProvider';
-import { Token, UserInfo } from '../../types';
+import { AuthProviderConfig, LoginRequest, LoginResponse, LogoutRequest, LogoutResponse, RefreshTokenRequest, RefreshTokenResponse } from '../interfaces/AuthProvider';
+import { ILoginProvider } from '../interfaces';
+import { Token, UserInfo, BaseResponse } from '../../types';
 import {
   loginByGoogle,
   logoutByGoogle,
@@ -11,22 +11,29 @@ import {
   checkGoogleServiceAvailability
 } from '../../api';
 
-export class GoogleAuthProvider extends BaseAuthProvider {
+export class GoogleAuthProvider implements ILoginProvider {
   readonly providerName = 'google' as const;
   readonly config: AuthProviderConfig;
   
   constructor(config: AuthProviderConfig) {
-    super();
     this.config = config;
   }
 
-  // OAuth 제공자는 이메일 인증코드를 지원하지 않음
-  async requestEmailVerification(request: EmailVerificationRequest): Promise<EmailVerificationResponse> {
-    return this.createResponse<EmailVerificationResponse>(
-      false,
-      'Google OAuth는 이메일 인증코드를 지원하지 않습니다.',
-      'UNSUPPORTED_FEATURE'
-    );
+  /**
+   * 공통 응답 생성 메서드 - 제네릭을 사용하여 타입 안전성 확보
+   */
+  protected createResponse<T extends BaseResponse>(
+    success: boolean, 
+    error?: string, 
+    errorCode?: string,
+    additionalData?: Partial<T>
+  ): T {
+    return {
+      success,
+      error,
+      errorCode,
+      ...additionalData
+    } as T;
   }
 
   async login(request: LoginRequest): Promise<LoginResponse> {

--- a/providers/interfaces/AuthProvider.ts
+++ b/providers/interfaces/AuthProvider.ts
@@ -1,5 +1,7 @@
 // 인증 제공자 인터페이스 및 DTO 정의
 import { Token, UserInfo, AuthProviderType } from '../../types';
+import { ILoginProvider } from './ILoginProvider';
+import { IEmailVerifiable } from './IEmailVerifiable';
 
 // 인증 제공자 설정 인터페이스
 export interface AuthProviderConfig {
@@ -73,63 +75,6 @@ export interface RefreshTokenResponse {
   error?: string;
 }
 
-// 인증 제공자 인터페이스
-export interface AuthProvider {
-  /**
-   * 제공자 이름
-   */
-  readonly providerName: AuthProviderType;
-  
-  /**
-   * 제공자 설정
-   */
-  readonly config: AuthProviderConfig;
-  
-  /**
-   * 이메일 인증번호를 요청합니다.
-   * @param request 이메일 인증번호 요청 정보
-   * @returns 인증번호 요청 결과
-   */
-  requestEmailVerification(request: EmailVerificationRequest): Promise<EmailVerificationResponse>;
-  
-  /**
-   * 로그인을 수행합니다.
-   * @param request 로그인 요청 정보
-   * @returns 로그인 결과
-   */
-  login(request: LoginRequest): Promise<LoginResponse>;
-  
-  /**
-   * 로그아웃을 수행합니다.
-   * @param request 로그아웃 요청 정보
-   * @returns 로그아웃 결과
-   */
-  logout(request: LogoutRequest): Promise<LogoutResponse>;
-  
-  /**
-   * 토큰을 갱신합니다.
-   * @param request 토큰 갱신 요청 정보
-   * @returns 토큰 갱신 결과
-   */
-  refreshToken(request: RefreshTokenRequest): Promise<RefreshTokenResponse>;
-  
-  /**
-   * 현재 토큰의 유효성을 검증합니다.
-   * @param token 검증할 토큰
-   * @returns 유효성 검증 결과
-   */
-  validateToken(token: Token): Promise<boolean>;
-  
-  /**
-   * 사용자 정보를 가져옵니다.
-   * @param token 인증 토큰
-   * @returns 사용자 정보
-   */
-  getUserInfo(token: Token): Promise<UserInfo | null>;
-  
-  /**
-   * 제공자가 사용 가능한지 확인합니다.
-   * @returns 사용 가능 여부
-   */
-  isAvailable(): Promise<boolean>;
-} 
+// 인증 제공자 인터페이스 - 하위 호환성을 위한 유니온 타입
+// 새로운 구현체는 ILoginProvider 또는 IEmailVerifiable을 직접 구현하는 것을 권장
+export type AuthProvider = ILoginProvider | (ILoginProvider & IEmailVerifiable); 

--- a/providers/interfaces/IEmailVerifiable.ts
+++ b/providers/interfaces/IEmailVerifiable.ts
@@ -1,0 +1,14 @@
+// 이메일 인증 기능 인터페이스
+import { 
+  EmailVerificationRequest,
+  EmailVerificationResponse
+} from './AuthProvider';
+
+export interface IEmailVerifiable {
+  /**
+   * 이메일 인증번호를 요청합니다.
+   * @param request 이메일 인증번호 요청 정보
+   * @returns 인증번호 요청 결과
+   */
+  requestEmailVerification(request: EmailVerificationRequest): Promise<EmailVerificationResponse>;
+} 

--- a/providers/interfaces/ILoginProvider.ts
+++ b/providers/interfaces/ILoginProvider.ts
@@ -1,0 +1,64 @@
+// 공통 로그인 기능 인터페이스
+import { Token, UserInfo } from '../../types';
+import { 
+  AuthProviderConfig,
+  LoginRequest, 
+  LoginResponse, 
+  LogoutRequest, 
+  LogoutResponse,
+  RefreshTokenRequest,
+  RefreshTokenResponse
+} from './AuthProvider';
+
+export interface ILoginProvider {
+  /**
+   * 제공자 이름
+   */
+  readonly providerName: string;
+  
+  /**
+   * 제공자 설정
+   */
+  readonly config: AuthProviderConfig;
+  
+  /**
+   * 로그인을 수행합니다.
+   * @param request 로그인 요청 정보
+   * @returns 로그인 결과
+   */
+  login(request: LoginRequest): Promise<LoginResponse>;
+  
+  /**
+   * 로그아웃을 수행합니다.
+   * @param request 로그아웃 요청 정보
+   * @returns 로그아웃 결과
+   */
+  logout(request: LogoutRequest): Promise<LogoutResponse>;
+  
+  /**
+   * 토큰을 갱신합니다.
+   * @param request 토큰 갱신 요청 정보
+   * @returns 토큰 갱신 결과
+   */
+  refreshToken(request: RefreshTokenRequest): Promise<RefreshTokenResponse>;
+  
+  /**
+   * 현재 토큰의 유효성을 검증합니다.
+   * @param token 검증할 토큰
+   * @returns 유효성 검증 결과
+   */
+  validateToken(token: Token): Promise<boolean>;
+  
+  /**
+   * 사용자 정보를 가져옵니다.
+   * @param token 인증 토큰
+   * @returns 사용자 정보
+   */
+  getUserInfo(token: Token): Promise<UserInfo | null>;
+  
+  /**
+   * 제공자가 사용 가능한지 확인합니다.
+   * @returns 사용 가능 여부
+   */
+  isAvailable(): Promise<boolean>;
+} 

--- a/providers/interfaces/index.ts
+++ b/providers/interfaces/index.ts
@@ -1,0 +1,4 @@
+// 인터페이스 export
+export * from './AuthProvider';
+export * from './ILoginProvider';
+export * from './IEmailVerifiable'; 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close #WQ-35


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

Interface Segregation Principle (ISP)을 적용하여 인증 제공자 인터페이스를 역할별로 분리하는 리팩토링을 수행했습니다.

1. 인터페이스 분리
ILoginProvider: 로그인, 로그아웃, 토큰 갱신 등 공통 인증 기능
IEmailVerifiable: 이메일 인증 관련 기능 (인증번호 요청 등)
2. 구현체별 인터페이스 적용
```ts
// 이메일 인증: 모든 기능 지원
export class EmailAuthProvider implements ILoginProvider, IEmailVerifiable { ... }

// OAuth 인증: 로그인 기능만 지원 (불필요한 메서드 제거)
export class GoogleAuthProvider implements ILoginProvider { ... }
```
3. BaseAuthProvider 역할 재정의
공통 응답 생성 메서드만 제공하는 유틸리티 클래스로 변경
추상 메서드들 모두 제거
4. AuthManager 타입 안전성 개선
타입 가드를 통한 안전한 메서드 호출
requestEmailVerification 메서드 사용 시 IEmailVerifiable 구현 여부 확인
- 변경 전:
    - OAuth 기반 인증 전략에서 불필요한 requestEmailVerification 메서드 구현 강제
    - 단일 인터페이스가 모든 기능을 강제하여 ISP 원칙 위반
- 변경 후:
    - 필요한 인터페이스만 선택적 구현
    - 코드 명확성 및 확장성 개선
    - 타입 안전성 향상

## 📷 스크린샷

> 이미지


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

인터페이스 분리 설계: ILoginProvider와 IEmailVerifiable 분리가 적절한지
타입 가드 구현: AuthManager의 isEmailVerifiable 타입 가드가 올바른지
확장성: 새로운 인증 전략 추가 시 인터페이스 구조가 유연한지

### 📌 PR 진행 시 참고사항

- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)