### PR TITLE
[WQ-62] refactor: 인증 응답 타입 안전성 개선

### DIFF
--- a/AuthManager.ts
+++ b/AuthManager.ts
@@ -103,10 +103,10 @@ export class AuthManager {
       // ④ 로그인 시도 (누가? 전달받은 provider가!)
       const loginResponse = await this.provider.login(request);
       
-      if (loginResponse.success && loginResponse.token) {
+      if (loginResponse.success && loginResponse.data?.token) {
         // ⑤ 로그인 성공 시 토큰 저장
-        await this.tokenStore.saveToken(loginResponse.token);
-        console.log('로그인 성공, 토큰 저장됨:', loginResponse.token);
+        await this.tokenStore.saveToken(loginResponse.data.token);
+        console.log('로그인 성공, 토큰 저장됨:', loginResponse.data.token);
       } else {
         // 타입 가드를 통해 error 속성에 안전하게 접근
         const errorMessage = 'error' in loginResponse ? loginResponse.error : '알 수 없는 오류';
@@ -174,9 +174,9 @@ export class AuthManager {
     try {
       const refreshResponse = await this.provider.refreshToken(request);
       
-      if (refreshResponse.success && refreshResponse.token) {
+      if (refreshResponse.success && refreshResponse.data) {
         // 토큰 갱신 성공 시 새로운 토큰 저장
-        await this.tokenStore.saveToken(refreshResponse.token);
+        await this.tokenStore.saveToken(refreshResponse.data);
         console.log('토큰 갱신 성공, 새 토큰 저장됨');
       }
       

--- a/network/emailAuthApi.ts
+++ b/network/emailAuthApi.ts
@@ -14,7 +14,7 @@ import {
   createToken, 
   createUserInfo 
 } from './utils/httpUtils';
-import { ApiConfig, ApiResponse, Token, UserInfo } from '../shared/types';
+import { ApiConfig, ApiResponse, Token, UserInfo, ErrorResponse } from '../shared/types';
 
 /**
  * 이메일 인증번호 요청
@@ -31,7 +31,7 @@ export async function requestEmailVerification(
         error: '이메일이 필요합니다.',
         message: '이메일이 필요합니다.',
         data: null
-      };
+      } as ErrorResponse;
     }
 
     const response = await makeRequestWithRetry(httpClient, config, config.endpoints.requestVerification, {
@@ -42,7 +42,7 @@ export async function requestEmailVerification(
     return handleHttpResponse(
       response,
       '인증번호 요청에 실패했습니다.',
-      (error) => ({ success: false, error, message: error, data: null }),
+      (error) => ({ success: false, error, message: error, data: null } as ErrorResponse),
       () => ({ success: true, data: undefined, message: '인증번호가 전송되었습니다.' })
     );
 
@@ -52,7 +52,7 @@ export async function requestEmailVerification(
       error: '네트워크 오류가 발생했습니다.',
       message: '네트워크 오류가 발생했습니다.',
       data: null
-    };
+    } as ErrorResponse;
   }
 }
 
@@ -72,7 +72,7 @@ export async function loginByEmail(
         error: '잘못된 인증 제공자입니다.',
         message: '잘못된 인증 제공자입니다.',
         data: null
-      };
+      } as ErrorResponse;
     }
 
     const emailRequest = request as EmailLoginRequest;
@@ -84,7 +84,7 @@ export async function loginByEmail(
         error: '이메일과 인증코드가 필요합니다.',
         message: '이메일과 인증코드가 필요합니다.',
         data: null
-      };
+      } as ErrorResponse;
     }
 
     const response = await makeRequestWithRetry(httpClient, config, config.endpoints.login, {
@@ -99,7 +99,7 @@ export async function loginByEmail(
     return handleHttpResponse(
       response,
       '로그인에 실패했습니다.',
-      (error: string) => ({ success: false, error, message: error, data: null }),
+      (error: string) => ({ success: false, error, message: error, data: null } as ErrorResponse),
       (data: unknown) => {
         const typedData = data as { accessToken: string; refreshToken: string; expiresAt?: number; user: { id: string; email: string; name: string } };
         const token = createToken(typedData);
@@ -114,7 +114,7 @@ export async function loginByEmail(
       error: '네트워크 오류가 발생했습니다.',
       message: '네트워크 오류가 발생했습니다.',
       data: null
-    };
+    } as ErrorResponse;
   }
 }
 
@@ -133,7 +133,7 @@ export async function logoutByEmail(
         error: '토큰이 필요합니다.',
         message: '토큰이 필요합니다.',
         data: null
-      };
+      } as ErrorResponse;
     }
 
     const response = await makeRequestWithRetry(httpClient, config, config.endpoints.logout, {
@@ -146,7 +146,7 @@ export async function logoutByEmail(
     return handleHttpResponse(
       response,
       '로그아웃에 실패했습니다.',
-      (error) => ({ success: false, error, message: error, data: null }),
+      (error) => ({ success: false, error, message: error, data: null } as ErrorResponse),
       () => ({ success: true, data: undefined, message: '로그아웃에 성공했습니다.' })
     );
 
@@ -156,7 +156,7 @@ export async function logoutByEmail(
       error: '네트워크 오류가 발생했습니다.',
       message: '네트워크 오류가 발생했습니다.',
       data: null
-    };
+    } as ErrorResponse;
   }
 }
 
@@ -177,7 +177,7 @@ export async function refreshTokenByEmail(
     return handleHttpResponse(
       response,
       '토큰 갱신에 실패했습니다.',
-      (error: string) => ({ success: false, error, message: error, data: null }),
+      (error: string) => ({ success: false, error, message: error, data: null } as ErrorResponse),
       (data: unknown) => {
         const typedData = data as { accessToken: string; refreshToken: string; expiresAt?: number };
         const token = createToken(typedData);
@@ -191,7 +191,7 @@ export async function refreshTokenByEmail(
       error: '네트워크 오류가 발생했습니다.',
       message: '네트워크 오류가 발생했습니다.',
       data: null
-    };
+    } as ErrorResponse;
   }
 }
 

--- a/network/utils/httpUtils.ts
+++ b/network/utils/httpUtils.ts
@@ -1,5 +1,5 @@
 // 인증 관련 네트워크 요청을 구성·처리하는 유틸 함수 모음
-import { ApiConfig, RequestOptions, ApiResponse, ApiSuccessResponse, ApiErrorResponse, Token, UserInfo, AuthProviderType } from '../../shared/types';
+import { ApiConfig, RequestOptions, ApiResponse, ApiSuccessResponse, Token, UserInfo, AuthProviderType, ErrorResponse } from '../../shared/types';
 import { HttpClient, HttpRequestConfig, HttpResponse } from '../interfaces/HttpClient';
 
 /**
@@ -71,7 +71,7 @@ export async function makeRequestWithRetry(
 export async function handleHttpResponse<T>(
   response: HttpResponse,
   errorMessage: string,
-  createErrorResponse: (error: string) => ApiErrorResponse,
+  createErrorResponse: (error: string) => ErrorResponse,
   createSuccessResponse: (data: unknown) => ApiSuccessResponse<T>
 ): Promise<ApiResponse<T>> {
   if (!response.ok) {

--- a/providers/base/BaseAuthProvider.ts
+++ b/providers/base/BaseAuthProvider.ts
@@ -1,21 +1,35 @@
 // 기본 인증 제공자 유틸리티 클래스 - 공통 응답 생성 메서드 제공
-import { BaseResponse } from '../../shared/types';
+import { BaseResponse, ErrorResponse } from '../../shared/types';
 
 export abstract class BaseAuthProvider {
   /**
-   * 공통 응답 생성 메서드 - 제네릭을 사용하여 타입 안전성 확보
+   * 성공 응답 생성 메서드
    */
-  protected createResponse<T extends BaseResponse>(
-    success: boolean, 
+  protected createSuccessResponse<T extends BaseResponse>(
     message: string,
-    error?: string, 
+    data?: unknown,
     additionalData?: Partial<T>
   ): T {
     return {
-      success,
+      success: true,
       message,
-      error,
+      data,
       ...additionalData
     } as T;
+  }
+
+  /**
+   * 실패 응답 생성 메서드
+   */
+  protected createErrorResponse(
+    message: string,
+    error: string
+  ): ErrorResponse {
+    return {
+      success: false,
+      message,
+      error,
+      data: null
+    };
   }
 } 

--- a/providers/implementations/GoogleAuthProvider.ts
+++ b/providers/implementations/GoogleAuthProvider.ts
@@ -4,6 +4,7 @@ import { LoginRequest, LoginResponse, LogoutRequest, LogoutResponse, RefreshToke
 import { ILoginProvider } from '../interfaces';
 import { Token, UserInfo, BaseResponse, ApiConfig } from '../../shared/types';
 import { HttpClient } from '../../network/interfaces/HttpClient';
+import { BaseAuthProvider } from '../base/BaseAuthProvider';
 import {
   loginByGoogle,
   logoutByGoogle,
@@ -13,50 +14,31 @@ import {
   checkGoogleServiceAvailability
 } from '../../network';
 
-export class GoogleAuthProvider implements ILoginProvider {
+export class GoogleAuthProvider extends BaseAuthProvider implements ILoginProvider {
   readonly providerName = 'google' as const;
   readonly config: AuthProviderConfig;
   private httpClient: HttpClient;
   private apiConfig: ApiConfig;
   
   constructor(config: AuthProviderConfig, httpClient: HttpClient, apiConfig: ApiConfig) {
+    super();
     this.config = config;
     this.httpClient = httpClient;
     this.apiConfig = apiConfig;
-  }
-
-  /**
-   * 공통 응답 생성 메서드 - 제네릭을 사용하여 타입 안전성 확보
-   */
-  protected createResponse<T extends BaseResponse>(
-    success: boolean, 
-    message: string,
-    error?: string, 
-    additionalData?: Partial<T>
-  ): T {
-    return {
-      success,
-      message,
-      error,
-      ...additionalData
-    } as T;
   }
 
   async login(request: LoginRequest): Promise<LoginResponse> {
     const apiResponse = await loginByGoogle(this.httpClient, this.apiConfig, request);
     
     if (!apiResponse.success) {
-      return this.createResponse<LoginResponse>(
-        false,
+      return this.createErrorResponse(
         apiResponse.error || 'Google 로그인에 실패했습니다.',
-        apiResponse.error
-      );
+        apiResponse.error || 'Google 로그인에 실패했습니다.'
+      ) as LoginResponse;
     }
 
-    return this.createResponse<LoginResponse>(
-      true,
+    return this.createSuccessResponse<LoginResponse>(
       'Google 로그인에 성공했습니다.',
-      undefined,
       apiResponse.data
     );
   }
@@ -65,31 +47,28 @@ export class GoogleAuthProvider implements ILoginProvider {
     const apiResponse = await logoutByGoogle(this.httpClient, this.apiConfig, request);
     
     if (!apiResponse.success) {
-      return this.createResponse<LogoutResponse>(
-        false,
+      return this.createErrorResponse(
         apiResponse.error || 'Google 로그아웃에 실패했습니다.',
-        apiResponse.error
-      );
+        apiResponse.error || 'Google 로그아웃에 실패했습니다.'
+      ) as LogoutResponse;
     }
 
-    return this.createResponse<LogoutResponse>(true, 'Google 로그아웃에 성공했습니다.');
+    return this.createSuccessResponse<LogoutResponse>('Google 로그아웃에 성공했습니다.');
   }
 
   async refreshToken(request: RefreshTokenRequest): Promise<RefreshTokenResponse> {
     const apiResponse = await refreshTokenByGoogle(this.httpClient, this.apiConfig, request);
     
     if (!apiResponse.success) {
-      return this.createResponse<RefreshTokenResponse>(
-        false,
+      return this.createErrorResponse(
         apiResponse.error || 'Google 토큰 갱신에 실패했습니다.',
-        apiResponse.error
-      );
+        apiResponse.error || 'Google 토큰 갱신에 실패했습니다.'
+      ) as RefreshTokenResponse;
     }
 
-    return this.createResponse<RefreshTokenResponse>(
-      true,
+    // apiResponse.data는 { token: Token } 형태
+    return this.createSuccessResponse<RefreshTokenResponse>(
       'Google 토큰 갱신에 성공했습니다.',
-      undefined,
       apiResponse.data
     );
   }

--- a/providers/interfaces/dtos/auth.dto.ts
+++ b/providers/interfaces/dtos/auth.dto.ts
@@ -1,5 +1,5 @@
 // 인증 관련 DTO 정의
-import { Token, UserInfo, BaseResponse, BaseRequest } from '../../../shared/types';
+import { Token, UserInfo, BaseResponse, ErrorResponse, BaseRequest } from '../../../shared/types';
 
 // 이메일 인증번호 요청 DTO
 export interface EmailVerificationRequest {
@@ -38,7 +38,7 @@ export interface LogoutRequest extends BaseRequest {
 
 // 로그아웃 응답 DTO
 export interface LogoutResponse extends BaseResponse<void> {
-  // BaseResponse의 success, error, message 필드를 상속받음
+  // BaseResponse의 success, message 필드를 상속받음
 }
 
 // 토큰 갱신 요청 DTO
@@ -49,4 +49,10 @@ export interface RefreshTokenRequest extends BaseRequest {
 // 토큰 갱신 응답 DTO
 export interface RefreshTokenResponse extends BaseResponse<Token> {
   token?: Token;
-} 
+}
+
+// 응답 타입들을 ErrorResponse와의 유니온 타입으로 정의
+export type EmailVerificationApiResponse = EmailVerificationResponse | ErrorResponse;
+export type LoginApiResponse = LoginResponse | ErrorResponse;
+export type LogoutApiResponse = LogoutResponse | ErrorResponse;
+export type RefreshTokenApiResponse = RefreshTokenResponse | ErrorResponse; 

--- a/providers/interfaces/dtos/auth.dto.ts
+++ b/providers/interfaces/dtos/auth.dto.ts
@@ -26,10 +26,7 @@ export interface OAuthLoginRequest extends BaseRequest {
 export type LoginRequest = EmailLoginRequest | OAuthLoginRequest;
 
 // 로그인 응답 DTO
-export interface LoginResponse extends BaseResponse<{ token: Token; userInfo: UserInfo }> {
-  token?: Token;
-  userInfo?: UserInfo;
-}
+export interface LoginResponse extends BaseResponse<{ token: Token; userInfo: UserInfo }> {}
 
 // 로그아웃 요청 DTO
 export interface LogoutRequest extends BaseRequest {
@@ -47,9 +44,7 @@ export interface RefreshTokenRequest extends BaseRequest {
 }
 
 // 토큰 갱신 응답 DTO
-export interface RefreshTokenResponse extends BaseResponse<Token> {
-  token?: Token;
-}
+export interface RefreshTokenResponse extends BaseResponse<Token> {}
 
 // 응답 타입들을 ErrorResponse와의 유니온 타입으로 정의
 export type EmailVerificationApiResponse = EmailVerificationResponse | ErrorResponse;

--- a/shared/types/api.ts
+++ b/shared/types/api.ts
@@ -1,7 +1,7 @@
 // API 관련 타입 정의
 // shared/types/api.ts
 
-import { BaseResponse } from './common';
+import { BaseResponse, ErrorResponse } from './common';
 
 // API 엔드포인트 설정
 export interface ApiEndpoints {
@@ -37,11 +37,8 @@ export interface ApiSuccessResponse<T = unknown> extends BaseResponse<T> {
 }
 
 // 실패 응답 타입
-export interface ApiErrorResponse extends BaseResponse<never> {
-  success: false;
-  error: string;
-  message: string;
-  data: null;
+export interface ApiErrorResponse extends ErrorResponse {
+  // ErrorResponse를 상속받아 error 필드 포함
 }
 
 // 통합 API 응답 타입

--- a/shared/types/auth.ts
+++ b/shared/types/auth.ts
@@ -1,15 +1,14 @@
 // 인증 관련 타입 정의
 // shared/types/auth.ts
 
+import { AuthProviderType } from './literals';
+
 // 기본 토큰 인터페이스
 export interface Token {
   accessToken: string;
   refreshToken?: string;
   expiresAt?: number; // unix timestamp
 }
-
-// 인증 제공자 타입
-export type AuthProviderType = 'email' | 'google';
 
 // 사용자 정보 인터페이스
 export interface UserInfo {

--- a/shared/types/common.ts
+++ b/shared/types/common.ts
@@ -1,6 +1,8 @@
 // 공통 응답 및 요청 인터페이스
 // shared/types/common.ts
 
+import { AuthProviderType } from './literals';
+
 // 공통 응답 인터페이스 (성공 응답 전용)
 export interface BaseResponse<T = unknown> {
   success: boolean;
@@ -9,7 +11,7 @@ export interface BaseResponse<T = unknown> {
 }
 
 // 실패 응답 인터페이스
-export interface ErrorResponse extends BaseResponse<never> {
+export interface ErrorResponse extends BaseResponse<null> {
   success: false;
   data: null;
   message: string;
@@ -18,6 +20,6 @@ export interface ErrorResponse extends BaseResponse<never> {
 
 // 공통 요청 인터페이스
 export interface BaseRequest {
-  provider: string; // AuthProviderType을 string으로 참조 (순환 참조 방지)
+  provider: AuthProviderType; // 타입 안전성 확보
   rememberMe?: boolean;
 }

--- a/shared/types/common.ts
+++ b/shared/types/common.ts
@@ -1,12 +1,19 @@
 // 공통 응답 및 요청 인터페이스
 // shared/types/common.ts
 
-// 공통 응답 인터페이스
+// 공통 응답 인터페이스 (성공 응답 전용)
 export interface BaseResponse<T = unknown> {
   success: boolean;
-  error?: string;
   message: string;
   data?: T | null;
+}
+
+// 실패 응답 인터페이스
+export interface ErrorResponse extends BaseResponse<never> {
+  success: false;
+  data: null;
+  message: string;
+  error: string;
 }
 
 // 공통 요청 인터페이스

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,6 +1,9 @@
 // 공통 타입 모음 인덱스
 // shared/types/index.ts
 
+// 리터럴 타입들
+export * from './literals';
+
 // 공통 응답 및 요청 인터페이스
 export * from './common';
 

--- a/shared/types/literals.ts
+++ b/shared/types/literals.ts
@@ -1,0 +1,5 @@
+// 인증 제공자 리터럴 타입 정의
+// shared/types/literals.ts
+
+// 인증 제공자 타입 (순환 참조 방지를 위해 별도 파일로 분리)
+export type AuthProviderType = 'email' | 'google';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close [WQ-62]


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


1. API 응답 구조 표준화
- BaseResponse를 성공 응답 전용으로 수정
- ErrorResponse를 별도로 생성하여 실패 응답 전용 구조 제공
- 모든 API 응답 타입을 BaseResponse | ErrorResponse 유니온으로 통합
2. 응답 생성 메서드 분리
- createResponse 메서드를 성공/실패 응답 생성 메서드로 분리
- EmailAuthProvider 및 GoogleAuthProvider에서 공통 응답 생성 로직 정리
3. API 응답 타입 일관성 확보
- AuthManager 및 관련 API 함수에서 응답 타입을 ErrorResponse로 변경
- 이메일 인증, 로그인, 로그아웃, 토큰 갱신 요청 시 오류 처리 개선
4. DTO 구조 개선
- LoginResponse와 RefreshTokenResponse의 중복 top-level 필드 제거
- AuthManager에서 data 필드를 통한 일관된 접근 방식 적용
5. 인증 제공자 타입 안전성 강화
- AuthProviderType을 리터럴 타입('email' | 'google')으로 정의하여 순환 참조 방지
- 타입 안전성을 통한 런타임 오류 사전 방지
## 📷 스크린샷

> 이미지


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

- 타입 정의 구조: AuthProviderType 리터럴 타입 정의가 적절한지 검토
- 응답 구조 설계: BaseResponse와 ErrorResponse 분리가 올바른 방향인지 확인
### 📌 PR 진행 시 참고사항

- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)