### PR TITLE
hotfix: AuthManager API 응답 타입 불일치 해결

### DIFF
--- a/AuthManager.ts
+++ b/AuthManager.ts
@@ -17,7 +17,7 @@ import {
   TokenValidationApiResponse,
   UserInfoApiResponse
 } from './providers/interfaces/dtos/auth.dto';
-import { createErrorResponse, createErrorResponseFromException } from './shared/utils/errorUtils';
+import { createErrorResponse, createErrorResponseFromException, createSuccessResponse } from './shared/utils';
 import { SuccessResponse, ErrorResponse } from './shared/types/common';
 
 // AuthManager 공개 API 응답 타입들
@@ -259,15 +259,14 @@ export class AuthManager {
     try {
       const hasTokenResult = await this.tokenStore.hasToken();
       if (!hasTokenResult.success || !hasTokenResult.data) {
-        return { success: true, data: false, message: '토큰이 없습니다.' };
+        return createSuccessResponse('토큰이 없습니다.', false);
       }
       
       const validationResult = await this.validateCurrentToken();
-      return { 
-        success: true, 
-        data: validationResult.success && validationResult.data, 
-        message: validationResult.success ? '인증 상태 확인 완료' : '토큰이 유효하지 않습니다.'
-      };
+      return createSuccessResponse(
+        validationResult.success ? '인증 상태 확인 완료' : '토큰이 유효하지 않습니다.',
+        validationResult.success && validationResult.data
+      );
     } catch (error) {
       console.error('인증 상태 확인 중 오류 발생:', error);
       return createErrorResponseFromException(error, '인증 상태 확인 중 오류가 발생했습니다.');

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,9 @@ export class AuthManager {
   async login(request: LoginRequest): Promise<LoginApiResponse>
   async logout(request: LogoutRequest): Promise<LogoutApiResponse>
   async requestEmailVerification(request: EmailVerificationRequest): Promise<EmailVerificationApiResponse>
-  async getToken(): Promise<Token | null>
+  async getToken(): Promise<GetTokenResponse>
+  async isAuthenticated(): Promise<IsAuthenticatedApiResponse>
+  async clear(): Promise<ClearResponse>
   async validateCurrentToken(): Promise<TokenValidationApiResponse>
 }
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,13 +126,21 @@ export async function loginByEmail(
 
 ```typescript
 export interface TokenStore {
-  saveToken(token: Token): Promise<{ success: boolean; error?: string }>;
-  getToken(): Promise<{ success: boolean; data?: Token; error?: string }>;
-  removeToken(): Promise<{ success: boolean; error?: string }>;
-  hasToken(): Promise<{ success: boolean; data?: boolean; error?: string }>;
-  isTokenExpired(): Promise<{ success: boolean; data?: boolean; error?: string }>;
-  clear(): Promise<{ success: boolean; error?: string }>;
+  saveToken(token: Token): Promise<SaveTokenResponse>;
+  getToken(): Promise<GetTokenResponse>;
+  removeToken(): Promise<RemoveTokenResponse>;
+  hasToken(): Promise<HasTokenResponse>;
+  isTokenExpired(): Promise<IsTokenExpiredResponse>;
+  clear(): Promise<ClearResponse>;
 }
+
+// 응답 타입 정의
+type SaveTokenResponse = SuccessResponse<null> | ErrorResponse;
+type GetTokenResponse = SuccessResponse<Token | null> | ErrorResponse;
+type RemoveTokenResponse = SuccessResponse<null> | ErrorResponse;
+type HasTokenResponse = SuccessResponse<boolean> | ErrorResponse;
+type IsTokenExpiredResponse = SuccessResponse<boolean> | ErrorResponse;
+type ClearResponse = SuccessResponse<null> | ErrorResponse;
 ```
 
 **책임**: 토큰의 안전한 저장, 조회, 삭제

--- a/network/emailAuthApi.ts
+++ b/network/emailAuthApi.ts
@@ -23,8 +23,9 @@ import {
   createTokenValidationErrorResponse,
   createUserInfoErrorResponse,
   createServiceAvailabilityErrorResponse,
-  createServerErrorResponse
-} from '../shared/utils/errorUtils';
+  createServerErrorResponse,
+  createSuccessResponse
+} from '../shared/utils';
 import { Token, UserInfo } from '../shared/types';
 
 /**
@@ -50,7 +51,7 @@ export async function requestEmailVerification(
       response,
       '인증번호 요청에 실패했습니다.',
       (error) => createErrorResponse(error),
-      () => ({ success: true, data: undefined, message: '인증번호가 전송되었습니다.' })
+      () => createSuccessResponse('인증번호가 전송되었습니다.', undefined)
     );
 
   } catch (error) {
@@ -96,7 +97,7 @@ export async function loginByEmail(
         const typedData = data as { accessToken: string; refreshToken: string; expiresAt?: number; user: { id: string; email: string; name: string } };
         const token = createToken(typedData);
         const userInfo = createUserInfo(typedData.user, 'email');
-        return { success: true, data: { token, userInfo }, message: '로그인에 성공했습니다.' };
+        return createSuccessResponse('로그인에 성공했습니다.', { token, userInfo });
       }
     );
 
@@ -129,7 +130,7 @@ export async function logoutByEmail(
       response,
       '로그아웃에 실패했습니다.',
       (error: string) => createErrorResponse(error),
-      () => ({ success: true, data: undefined, message: '로그아웃에 성공했습니다.' })
+      () => createSuccessResponse('로그아웃에 성공했습니다.', undefined)
     );
 
   } catch (error) {
@@ -162,7 +163,7 @@ export async function refreshTokenByEmail(
               (data: unknown) => {
           const typedData = data as { accessToken: string; refreshToken: string; expiresAt?: number };
           const token = createToken(typedData);
-          return { success: true, data: token, message: '토큰 갱신에 성공했습니다.' };
+          return createSuccessResponse('토큰 갱신에 성공했습니다.', token);
         }
     );
 
@@ -192,7 +193,7 @@ export async function validateTokenByEmail(
     });
 
     if (response.ok) {
-      return { success: true, data: true, message: '토큰이 유효합니다.' };
+      return createSuccessResponse('토큰이 유효합니다.', true);
     } else {
       return createTokenValidationErrorResponse(`HTTP ${response.status}: ${response.statusText}`);
     }
@@ -234,7 +235,7 @@ export async function getUserInfoByEmail(
     try {
       const data = await response.json();
       const userInfo = createUserInfo(data, 'email');
-      return { success: true, data: userInfo, message: '사용자 정보를 성공적으로 가져왔습니다.' };
+      return createSuccessResponse('사용자 정보를 성공적으로 가져왔습니다.', userInfo);
     } catch (parseError) {
       return createUserInfoErrorResponse('응답 데이터 파싱에 실패했습니다.');
     }
@@ -257,7 +258,7 @@ export async function checkEmailServiceAvailability(
     });
 
     if (response.ok) {
-      return { success: true, data: true, message: '서비스가 정상적으로 작동하고 있습니다.' };
+      return createSuccessResponse('서비스가 정상적으로 작동하고 있습니다.', true);
     } else {
       if (response.status >= 500) {
         return createServerErrorResponse(response.status);

--- a/providers/base/BaseAuthProvider.ts
+++ b/providers/base/BaseAuthProvider.ts
@@ -1,5 +1,6 @@
 // 기본 인증 제공자 유틸리티 클래스 - 공통 응답 생성 메서드 제공
 import { SuccessResponse, ErrorResponse } from '../../shared/types';
+import { createSuccessResponse as createBaseSuccessResponse, createErrorResponse as createBaseErrorResponse } from '../../shared/utils';
 
 export abstract class BaseAuthProvider {
   /**
@@ -10,10 +11,9 @@ export abstract class BaseAuthProvider {
     data: T,
     additionalData?: Partial<Omit<SuccessResponse<T>, 'success' | 'data'>>
   ): SuccessResponse<T> {
+    const baseResponse = createBaseSuccessResponse(message, data);
     return {
-      success: true,
-      message,
-      data,
+      ...baseResponse,
       ...additionalData
     };
   }
@@ -25,11 +25,6 @@ export abstract class BaseAuthProvider {
     message: string,
     error: string
   ): ErrorResponse {
-    return {
-      success: false,
-      message,
-      error,
-      data: null
-    };
+    return createBaseErrorResponse(error, message);
   }
 } 

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -1,1 +1,18 @@
 export * from './errorUtils';
+
+// 성공 응답 생성 유틸리티 함수
+import { SuccessResponse } from '../types/common';
+
+/**
+ * 성공 응답 생성 함수
+ */
+export function createSuccessResponse<T>(
+  message: string,
+  data: T
+): SuccessResponse<T> {
+  return {
+    success: true,
+    message,
+    data
+  };
+}

--- a/storage/FakeTokenStore.ts
+++ b/storage/FakeTokenStore.ts
@@ -60,12 +60,7 @@ export const FakeTokenStore: TokenStore = {
       );
     } catch (error) {
       console.error('토큰 존재 확인 중 오류 발생:', error);
-      return { 
-        success: false, 
-        error: '토큰 존재 확인 실패', 
-        message: '토큰 존재 확인 중 오류가 발생했습니다.', 
-        data: null 
-      };
+      return createTokenReadErrorResponse('토큰 존재 확인 중 오류가 발생했습니다.');
     }
   },
 
@@ -82,12 +77,7 @@ export const FakeTokenStore: TokenStore = {
       );
     } catch (error) {
       console.error('토큰 만료 확인 중 오류 발생:', error);
-      return { 
-        success: false, 
-        error: '토큰 만료 확인 실패', 
-        message: '토큰 만료 확인 중 오류가 발생했습니다.', 
-        data: null 
-      };
+      return createTokenReadErrorResponse('토큰 만료 확인 중 오류가 발생했습니다.');
     }
   },
 

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -5,36 +5,6 @@ export * from './TokenStore.interface';
 // export { MobileTokenStore } from './MobileTokenStore';
 export { FakeTokenStore } from './FakeTokenStore';
 
-// Storage 레이어 전용 응답 생성 유틸리티
-import { SuccessResponse, ErrorResponse } from '../shared/types';
-
-/**
- * Storage 레이어에서 사용하는 성공 응답 생성 함수
- * Provider 레이어에 의존하지 않음
- */
-export function createStorageSuccessResponse<T>(
-  message: string,
-  data: T
-): SuccessResponse<T> {
-  return {
-    success: true,
-    message,
-    data
-  };
-}
-
-/**
- * Storage 레이어에서 사용하는 에러 응답 생성 함수
- * Provider 레이어에 의존하지 않음
- */
-export function createStorageErrorResponse(
-  message: string,
-  error: string
-): ErrorResponse {
-  return {
-    success: false,
-    message,
-    error,
-    data: null
-  };
-} 
+// Storage 레이어 전용 응답 생성 유틸리티 (공통 유틸리티 재사용)
+export { createSuccessResponse as createStorageSuccessResponse } from '../shared/utils';
+export { createErrorResponse as createStorageErrorResponse } from '../shared/utils'; 


### PR DESCRIPTION
## 📝 작업 내용
- 문제: AuthManager.ts에 공개 API가 구조화된 응답 API를 사용하지 않고 있었음. 
#14 에서 수정한 내용이 반영되지 않음.
- 해결: 구조화된 API응답 형태로 통일하였고, 문서파일에 적용되지 않은 부분도 수정했습니다.