### PR TITLE
[WQ-100] refactor:  쿠키 기반 refreshToken 인증 시스템 구현

### DIFF
--- a/examples/web-demo/src/http-clients/MSWHttpClient.ts
+++ b/examples/web-demo/src/http-clients/MSWHttpClient.ts
@@ -39,7 +39,12 @@ export class MSWHttpClient implements HttpClient {
         statusText: response.statusText,
         headers: Object.fromEntries(response.headers.entries()),
         text: async () => responseData,
-        json: async () => responseData
+        json: async () => responseData,
+        getCookies: () => {
+          // Set-Cookie 헤더에서 쿠키 추출
+          const setCookieHeaders = response.headers.get('set-cookie');
+          return setCookieHeaders ? setCookieHeaders.split(',').map(cookie => cookie.trim()) : [];
+        }
       };
       
     } catch (error) {
@@ -54,7 +59,8 @@ export class MSWHttpClient implements HttpClient {
           message: error instanceof Error ? error.message : '알 수 없는 오류',
           data: null,
           error: error instanceof Error ? error.message : '알 수 없는 오류'
-        })
+        }),
+        getCookies: () => []
       };
     }
   }

--- a/examples/web-demo/src/http-clients/MockHttpClient.ts
+++ b/examples/web-demo/src/http-clients/MockHttpClient.ts
@@ -25,7 +25,8 @@ export class MockHttpClient implements HttpClient {
           message: '인증번호가 전송되었습니다.',
           data: null
         }),
-        text: async () => '{"success":true,"message":"인증번호가 전송되었습니다.","data":null}'
+        text: async () => '{"success":true,"message":"인증번호가 전송되었습니다.","data":null}',
+        getCookies: () => []
       };
     }
     
@@ -57,7 +58,8 @@ export class MockHttpClient implements HttpClient {
             data: null,
             error: 'INVALID_VERIFICATION_CODE'
           }),
-          text: async () => '{"success":false,"message":"잘못된 인증번호입니다.","error":"INVALID_VERIFICATION_CODE"}'
+          text: async () => '{"success":false,"message":"잘못된 인증번호입니다.","error":"INVALID_VERIFICATION_CODE"}',
+          getCookies: () => []
         };
       }
       
@@ -72,7 +74,8 @@ export class MockHttpClient implements HttpClient {
           message: '이메일 인증이 완료되었습니다.',
           data: null
         }),
-        text: async () => '{"success":true,"message":"이메일 인증이 완료되었습니다.","data":null}'
+        text: async () => '{"success":true,"message":"이메일 인증이 완료되었습니다.","data":null}',
+        getCookies: () => []
       };
     }
     
@@ -104,7 +107,8 @@ export class MockHttpClient implements HttpClient {
             data: null,
             error: 'EMAIL_REQUIRED'
           }),
-          text: async () => '{"success":false,"message":"이메일이 필요합니다.","error":"EMAIL_REQUIRED"}'
+          text: async () => '{"success":false,"message":"이메일이 필요합니다.","error":"EMAIL_REQUIRED"}',
+          getCookies: () => []
         };
       }
 
@@ -121,22 +125,26 @@ export class MockHttpClient implements HttpClient {
             data: null,
             error: 'EMAIL_VERIFICATION_REQUIRED'
           }),
-          text: async () => '{"success":false,"message":"이메일 인증이 필요합니다.","error":"EMAIL_VERIFICATION_REQUIRED"}'
+          text: async () => '{"success":false,"message":"이메일 인증이 필요합니다.","error":"EMAIL_VERIFICATION_REQUIRED"}',
+          getCookies: () => []
         };
       }
       
-      // 올바른 이메일인 경우 성공 응답
+      // 올바른 이메일인 경우 성공 응답 (쿠키 기반)
+      const refreshToken = this.generateRandomToken('mock-refresh-token');
       return {
         ok: true,
         status: 200,
         statusText: 'OK',
-        headers: {},
+        headers: {
+          'set-cookie': `refreshToken=${refreshToken}; HttpOnly; Secure; SameSite=Strict`
+        },
         json: async () => ({
           success: true,
           message: '로그인에 성공했습니다.',
           data: {
             accessToken: this.generateRandomToken('mock-access-token'),
-            refreshToken: this.generateRandomToken('mock-refresh-token'),
+            // refreshToken은 쿠키로 전송되므로 응답 바디에 포함하지 않음
             expiredAt: this.generateExpiredAt(),
             userInfo: {
               id: 'user-123',
@@ -146,7 +154,8 @@ export class MockHttpClient implements HttpClient {
             }
           }
         }),
-        text: async () => 'mock login response'
+        text: async () => 'mock login response',
+        getCookies: () => [`refreshToken=${refreshToken}; HttpOnly; Secure; SameSite=Strict`]
       };
     }
     
@@ -161,7 +170,8 @@ export class MockHttpClient implements HttpClient {
           message: '토큰이 유효합니다.',
           data: true
         }),
-        text: async () => '{"success":true,"message":"토큰이 유효합니다.","data":true}'
+        text: async () => '{"success":true,"message":"토큰이 유효합니다.","data":true}',
+        getCookies: () => []
       };
     }
     
@@ -181,7 +191,8 @@ export class MockHttpClient implements HttpClient {
             provider: 'email'
           }
         }),
-        text: async () => 'mock user info response'
+        text: async () => 'mock user info response',
+        getCookies: () => []
       };
     }
     if (url.includes('/api/v1/auth/members/refresh') && method === 'POST') {
@@ -199,7 +210,8 @@ export class MockHttpClient implements HttpClient {
             expiredAt: this.generateExpiredAt()
           }
         }),
-        text: async () => 'mock refresh response'
+        text: async () => 'mock refresh response',
+        getCookies: () => []
       };
     }
     if (url.includes('/api/v1/auth/members/logout') && method === 'POST') {
@@ -213,7 +225,8 @@ export class MockHttpClient implements HttpClient {
           message: '로그아웃에 성공했습니다.',
           data: null
         }),
-        text: async () => '{"success":true,"message":"로그아웃에 성공했습니다.","data":null}'
+        text: async () => '{"success":true,"message":"로그아웃에 성공했습니다.","data":null}',
+        getCookies: () => []
       };
     }
     
@@ -245,22 +258,26 @@ export class MockHttpClient implements HttpClient {
             data: null,
             error: 'INVALID_GOOGLE_TOKEN'
           }),
-          text: async () => '{"success":false,"message":"잘못된 구글 토큰입니다.","error":"INVALID_GOOGLE_TOKEN"}'
+          text: async () => '{"success":false,"message":"잘못된 구글 토큰입니다.","error":"INVALID_GOOGLE_TOKEN"}',
+          getCookies: () => []
         };
       }
       
-      // 올바른 구글 토큰인 경우 성공 응답
+      // 올바른 구글 토큰인 경우 성공 응답 (쿠키 기반)
+      const refreshToken = this.generateRandomToken('google-refresh-token');
       return {
         ok: true,
         status: 200,
         statusText: 'OK',
-        headers: {},
+        headers: {
+          'set-cookie': `refreshToken=${refreshToken}; HttpOnly; Secure; SameSite=Strict`
+        },
         json: async () => ({
           success: true,
           message: '구글 로그인에 성공했습니다.',
           data: {
             accessToken: this.generateRandomToken('google-access-token'),
-            refreshToken: this.generateRandomToken('google-refresh-token'),
+            // refreshToken은 쿠키로 전송되므로 응답 바디에 포함하지 않음
             expiredAt: this.generateExpiredAt(),
             userInfo: {
               id: 'google-user-123',
@@ -270,7 +287,8 @@ export class MockHttpClient implements HttpClient {
             }
           }
         }),
-        text: async () => 'mock google login response'
+        text: async () => 'mock google login response',
+        getCookies: () => [`refreshToken=${refreshToken}; HttpOnly; Secure; SameSite=Strict`]
       };
     }
 
@@ -286,7 +304,8 @@ export class MockHttpClient implements HttpClient {
           message: '구글 로그아웃에 성공했습니다.',
           data: null
         }),
-        text: async () => '{"success":true,"message":"구글 로그아웃에 성공했습니다.","data":null}'
+        text: async () => '{"success":true,"message":"구글 로그아웃에 성공했습니다.","data":null}',
+        getCookies: () => []
       };
     }
 
@@ -307,7 +326,8 @@ export class MockHttpClient implements HttpClient {
             tokenType: 'Bearer'
           }
         }),
-        text: async () => 'mock google refresh response'
+        text: async () => 'mock google refresh response',
+        getCookies: () => []
       };
     }
     
@@ -325,7 +345,8 @@ export class MockHttpClient implements HttpClient {
             timestamp: new Date().toISOString()
           }
         }),
-        text: async () => 'mock health response'
+        text: async () => 'mock health response',
+        getCookies: () => []
       };
     }
     
@@ -340,7 +361,8 @@ export class MockHttpClient implements HttpClient {
         message: `지원하지 않는 엔드포인트: ${method} ${url}`,
         error: 'ENDPOINT_NOT_FOUND'
       }),
-      text: async () => `지원하지 않는 엔드포인트: ${method} ${url}`
+      text: async () => `지원하지 않는 엔드포인트: ${method} ${url}`,
+      getCookies: () => []
     };
   }
 

--- a/examples/web-demo/src/http-clients/RealHttpClient.ts
+++ b/examples/web-demo/src/http-clients/RealHttpClient.ts
@@ -84,6 +84,11 @@ export class RealHttpClient implements HttpClient {
         headers: Object.fromEntries(response.headers.entries()),
         json: async () => data,
         text: async () => (typeof data === 'string' ? data : JSON.stringify(data)),
+        getCookies: () => {
+          // Set-Cookie 헤더에서 쿠키 추출
+          const setCookieHeaders = response.headers.get('set-cookie');
+          return setCookieHeaders ? setCookieHeaders.split(',').map(cookie => cookie.trim()) : [];
+        }
       };
     } catch (error) {
       // 네트워크/타임아웃/규칙 위반 등
@@ -94,6 +99,7 @@ export class RealHttpClient implements HttpClient {
         headers: {},
         json: async () => ({ error: error instanceof Error ? error.message : '알 수 없는 오류' }),
         text: async () => (error instanceof Error ? error.message : '알 수 없는 오류'),
+        getCookies: () => []
       };
     }
   }

--- a/examples/web-demo/src/main.ts
+++ b/examples/web-demo/src/main.ts
@@ -321,6 +321,14 @@ class AuthDemo {
       const codeVerifier = this.generateCodeVerifier();
       const codeChallenge = await this.generateCodeChallenge(codeVerifier);
       
+      // 🔐 PKCE 정보 로깅 (보안을 위해 일부만 표시)
+      const codeVerifierPreview = codeVerifier.substring(0, 10) + '...' + codeVerifier.substring(codeVerifier.length - 10);
+      const codeChallengePreview = codeChallenge.substring(0, 10) + '...' + codeChallenge.substring(codeChallenge.length - 10);
+      console.log('🔐 PKCE 생성 완료:');
+      console.log('  - code_verifier:', codeVerifierPreview);
+      console.log('  - code_challenge:', codeChallengePreview);
+      this.updateStatus(`🔐 PKCE 보안 파라미터 생성 완료`, 'info');
+      
       // state와 code_verifier를 localStorage에 저장 (보안을 위해)
       localStorage.setItem('google_oauth_state', state);
       localStorage.setItem('google_oauth_code_verifier', codeVerifier);
@@ -338,7 +346,8 @@ class AuthDemo {
       
       this.updateStatus('Google OAuth 페이지로 이동합니다...', 'info');
       
-      // 팝업 창으로 OAuth 열기 (MSW 모킹을 위해)
+      // 팝업 창으로 OAuth 열기
+      console.log('🌐 구글 OAuth URL:', googleAuthUrl);
       const popup = window.open(googleAuthUrl, 'google_oauth', 'width=500,height=600');
       
       if (!popup) {
@@ -361,6 +370,11 @@ class AuthDemo {
       }
 
       console.log('Google OAuth 콜백 처리 시작');
+      
+      // 🔍 구글 인증 서버에서 받은 authCode 확인 (보안을 위해 일부만 표시)
+      const authCodePreview = code.substring(0, 10) + '...' + code.substring(code.length - 10);
+      console.log('✅ 구글 인증 서버에서 받은 authCode:', authCodePreview);
+      this.updateStatus(`✅ 구글 인증 서버에서 authCode를 받았습니다: ${authCodePreview}`, 'info');
       
       // 저장된 state와 비교 (보안 검증)
       const savedState = localStorage.getItem('google_oauth_state');
@@ -404,11 +418,17 @@ class AuthDemo {
       const googleAuthManager = new AuthManager({
         providerType: 'google',
         apiConfig,
-        httpClient: new MSWHttpClient(),
+        httpClient: new RealHttpClient(), // MSW 대신 실제 HTTP 클라이언트 사용
         providerConfig: googleConfig
       });
 
       // 받은 authCode로 로그인 시도
+      console.log('🚀 백엔드로 authCode 전송 시작:', authCodePreview);
+      console.log('📤 전송할 데이터:', {
+        authCode: authCodePreview,
+        codeVerifier: localStorage.getItem('google_oauth_code_verifier')?.substring(0, 10) + '...'
+      });
+      
       const result = await googleAuthManager.login({ 
         provider: 'google',
         authCode: code  // ← 실제 받은 authCode 사용!

--- a/src/network/emailAuthApi.ts
+++ b/src/network/emailAuthApi.ts
@@ -135,13 +135,11 @@ export async function logoutByEmail(
   request: LogoutRequest
 ): Promise<LogoutApiResponse> {
   try {
-    if (!request.refreshToken) {
-      return createValidationErrorResponse('리프레시 토큰');
-    }
-
+    // 쿠키 기반 로그아웃: 쿠키를 헤더로 전송 (백엔드에서 쿠키에서 refreshToken 추출)
     const response = await makeRequestWithRetry(httpClient, config, config.endpoints.logout, {
       method: 'POST',
-      body: { refreshToken: request.refreshToken }
+      // 쿠키는 브라우저가 자동으로 전송하므로 별도 설정 불필요
+      // body에 refreshToken을 포함하지 않음
     });
 
     const data = await handleHttpResponse<LogoutApiResponse>(response, '로그아웃에 실패했습니다.');

--- a/src/network/googleAuthApi.ts
+++ b/src/network/googleAuthApi.ts
@@ -60,17 +60,15 @@ export async function logoutByGoogle(
   request: LogoutRequest
 ): Promise<LogoutApiResponse> {
   try {
-    if (!request.refreshToken) {
-      return createValidationErrorResponse('리프레시 토큰');
-    }
-
+    // 쿠키 기반 로그아웃: 쿠키를 헤더로 전송 (백엔드에서 쿠키에서 refreshToken 추출)
     const response = await makeRequestWithRetry(
       httpClient, 
       config, 
       config.endpoints.googleLogout,  // logout → googleLogout으로 변경
       {
         method: 'POST',
-        body: { refreshToken: request.refreshToken }
+        // 쿠키는 브라우저가 자동으로 전송하므로 별도 설정 불필요
+        // body에 refreshToken을 포함하지 않음
       }
     );
 

--- a/src/network/interfaces/HttpClient.ts
+++ b/src/network/interfaces/HttpClient.ts
@@ -19,6 +19,8 @@ export interface HttpResponse {
   headers: Record<string, string>;
   json(): Promise<any>;
   text(): Promise<string>;
+  // 쿠키 관련 메서드 추가
+  getCookies(): string[]; // Set-Cookie 헤더에서 쿠키 추출
 }
 
 export interface HttpClient {

--- a/src/providers/interfaces/dtos/auth.dto.ts
+++ b/src/providers/interfaces/dtos/auth.dto.ts
@@ -35,10 +35,10 @@ export interface OAuthLoginRequest extends BaseRequest {
 // 통합 로그인 요청 DTO (유니온 타입)
 export type LoginRequest = EmailLoginRequest | OAuthLoginRequest;
 
-// 백엔드 로그인 응답 데이터 구조
+// 백엔드 로그인 응답 데이터 구조 (쿠키 기반)
 export interface LoginResponseData {
-  accessToken: string;
-  refreshToken: string;
+  accessToken: string; // 응답 바디로 받음
+  // refreshToken은 쿠키로 받음 (응답 바디에 포함되지 않음)
   expiredAt?: number;
   userInfo: UserInfo;
 }
@@ -46,9 +46,9 @@ export interface LoginResponseData {
 // 로그인 응답 DTO
 export interface LoginResponse extends SuccessResponse<LoginResponseData> {}
 
-// 로그아웃 요청 DTO
+// 로그아웃 요청 DTO (쿠키 기반)
 export interface LogoutRequest extends BaseRequest {
-  refreshToken?: string; // 선택적 필드 (AuthManager에서 자동으로 채움)
+  // refreshToken은 쿠키에서 자동으로 추출됨 (요청 바디에 포함되지 않음)
 }
 
 // 로그아웃 응답 DTO

--- a/test/integration/auth-manager-email-integration.test.ts
+++ b/test/integration/auth-manager-email-integration.test.ts
@@ -580,7 +580,7 @@ async function printTestSummary(testResults: TestResult[], startTime: number): P
 // 환경 변수 TEST_MODE에 따라 적절한 테스트 모드를 설정합니다.
 
 async function main() {
-  const testMode = process.env.TEST_MODE || 'local';
+  const testMode = process.argv[2] || process.env.TEST_MODE || 'local';
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
   console.log(`🔧 테스트 모드: ${testMode}`);
@@ -631,7 +631,7 @@ async function main() {
     const { startMSWServer, stopMSWServer } = await import('../setup/msw.server');
     
     console.log('🚀 MSW 서버를 시작합니다...');
-    startMSWServer();
+    await startMSWServer();
     console.log('✅ MSW 서버가 시작되었습니다.');
     console.log('📡 모킹된 API 엔드포인트:');
     console.log(`   - POST ${apiConfig.endpoints.requestVerification}`);

--- a/test/integration/auth-manager-google-integration.test.ts
+++ b/test/integration/auth-manager-google-integration.test.ts
@@ -232,7 +232,7 @@ async function testGoogleOAuthTokenManagement(authManager: AuthManager): Promise
     console.log('    4단계: 토큰 갱신 테스트');
     const refreshRequest: RefreshTokenRequest = {
       provider: 'google',
-      refreshToken: loginResponse.data?.refreshToken || 'invalid-refresh-token'
+      refreshToken: '' // 쿠키 기반 인증에서는 refreshToken이 쿠키로 관리됨
     };
     const refreshResponse = await authManager.refreshToken(refreshRequest);
     if (!refreshResponse.success) {
@@ -416,7 +416,7 @@ async function printTestSummary(testResults: TestResult[], startTime: number): P
 // 환경 변수 TEST_MODE에 따라 적절한 테스트 모드를 설정합니다.
 
 async function main() {
-  const testMode = process.env.TEST_MODE || 'local';
+  const testMode = process.argv[2] || process.env.TEST_MODE || 'local';
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
   console.log(`🔧 테스트 모드: ${testMode}`);
@@ -475,7 +475,7 @@ async function main() {
     const { startMSWServer, stopMSWServer } = await import('../setup/msw.server');
     
     console.log('🚀 MSW 서버를 시작합니다...');
-    startMSWServer();
+    await startMSWServer();
     console.log('✅ MSW 서버가 시작되었습니다.');
     console.log('📡 모킹된 Google OAuth API 엔드포인트:');
     console.log(`   - POST ${apiConfig.endpoints.googleLogin}`);

--- a/test/mocks/FakeHttpClient.ts
+++ b/test/mocks/FakeHttpClient.ts
@@ -36,7 +36,8 @@ export class FakeHttpClient implements HttpClient {
       statusText: 'OK',
       headers: {},
       json: async () => ({}),
-      text: async () => ''
+      text: async () => '',
+      getCookies: () => []
     };
   }
 

--- a/test/mocks/MSWHttpClient.ts
+++ b/test/mocks/MSWHttpClient.ts
@@ -24,7 +24,12 @@ export class MSWHttpClient implements HttpClient {
         statusText: response.statusText,
         headers: Object.fromEntries(response.headers.entries()),
         text: async () => responseData,
-        json: async () => responseData
+        json: async () => responseData,
+        getCookies: () => {
+          // Set-Cookie 헤더에서 쿠키 추출
+          const setCookieHeaders = response.headers.get('set-cookie');
+          return setCookieHeaders ? setCookieHeaders.split(',').map(cookie => cookie.trim()) : [];
+        }
       };
       
     } catch (error) {
@@ -39,7 +44,8 @@ export class MSWHttpClient implements HttpClient {
           message: error instanceof Error ? error.message : '알 수 없는 오류',
           data: null,
           error: error instanceof Error ? error.message : '알 수 없는 오류'
-        })
+        }),
+        getCookies: () => []
       };
     }
   }

--- a/test/setup/msw.handlers.ts
+++ b/test/setup/msw.handlers.ts
@@ -58,8 +58,8 @@ export const handlers = [
       }, { status: 404 });
     }
     
-    // 인증 코드 생성 및 저장
-    const verificationCode = Math.floor(100000 + Math.random() * 900000).toString();
+    // 인증 코드 생성 및 저장 (테스트용으로 고정값 사용)
+    const verificationCode = '123456';
     verificationCodes.set(body.email, verificationCode);
     
     // 테스트 환경에서는 콘솔에 인증 코드 출력 (실제로는 이메일로 전송)
@@ -154,12 +154,14 @@ export const handlers = [
       }, { status: 401 });
     }
     
+    // 쿠키 기반 로그인 응답
+    const refreshToken = generateRandomToken('mock-refresh-token');
     return HttpResponse.json({
       success: true,
       message: '로그인에 성공했습니다.',
       data: {
         accessToken: generateRandomToken('mock-access-token'),
-        refreshToken: generateRandomToken('mock-refresh-token'),
+        // refreshToken은 쿠키로 전송되므로 응답 바디에 포함하지 않음
         expiredAt: generateExpiredAt(),
         userInfo: {
           id: 'user-123',
@@ -167,6 +169,10 @@ export const handlers = [
           nickname: '테스트 사용자',
           provider: 'email'
         }
+      }
+    }, {
+      headers: {
+        'Set-Cookie': `refreshToken=${refreshToken}; HttpOnly; Secure; SameSite=Strict`
       }
     });
   }),
@@ -201,12 +207,13 @@ export const handlers = [
     const googleAccessToken = generateRandomToken('google-access-token');
     const googleRefreshToken = generateRandomToken('google-refresh-token');
 
+    // 쿠키 기반 구글 로그인 응답
     return HttpResponse.json({
       success: true,
       message: '구글 로그인에 성공했습니다.',
       data: {
         accessToken: googleAccessToken,
-        refreshToken: googleRefreshToken,
+        // refreshToken은 쿠키로 전송되므로 응답 바디에 포함하지 않음
         expiredAt: generateExpiredAt(),
         userInfo: {
           id: 'google-user-123',
@@ -214,6 +221,10 @@ export const handlers = [
           nickname: '구글 사용자',
           provider: 'google'
         }
+      }
+    }, {
+      headers: {
+        'Set-Cookie': `refreshToken=${googleRefreshToken}; HttpOnly; Secure; SameSite=Strict`
       }
     });
   }),

--- a/test/unit/auth-manager.test.ts
+++ b/test/unit/auth-manager.test.ts
@@ -258,7 +258,7 @@ describe('AuthManager (단위 테스트 - 백엔드 없음)', () => {
       }
     });
 
-    it('토큰이 없는 상태에서 로그아웃 시도 시 에러 처리', async () => {
+    it('토큰이 없는 상태에서 로그아웃 시도 시 성공 처리 (쿠키 기반)', async () => {
       // Given: 토큰이 없는 상태 (초기 상태)
       const tokenResult = await manager.getToken();
       expect(tokenResult.success).toBe(true);
@@ -269,10 +269,10 @@ describe('AuthManager (단위 테스트 - 백엔드 없음)', () => {
       // When: 로그아웃 실행
       const logoutResult = await manager.logout({ provider: 'email' as const });
 
-      // Then: 로그아웃 실패 (저장된 토큰이 없음)
-      expect(logoutResult.success).toBe(false);
-      if (!logoutResult.success) {
-        expect(logoutResult.message).toContain('저장된 토큰이 없습니다');
+      // Then: 쿠키 기반 로그아웃에서는 토큰이 없어도 성공 처리
+      expect(logoutResult.success).toBe(true);
+      if (logoutResult.success) {
+        expect(logoutResult.message).toContain('로그아웃');
       }
     });
   });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close [WQ-100]


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존의 토큰 전송 방식을 쿠키 기반 인증으로 변경하여 보안성을 향상시켰습니다.
- 기존 상황
    - 로그인: accessToken과 refreshToken을 모두 응답 바디로 받음
    - 로그아웃:  refreshToken을 요청 바디로 전송
- 변경된 사항
    - 로그인:  refreshToken은 쿠키로, accessToken은 응답 바디로 받기
    - 로그아웃:  브라우저가 자동으로 쿠키를 헤더에 포함하여 전송

1. DTO 수정
- LoginResponseData에서 refreshToken 필드 제거
- LogoutRequest에서 refreshToken 필드 제거
2. HttpClient 인터페이스 확장
- HttpResponse에 getCookies() 메서드 추가하여 쿠키 추출 지원
3. API 레이어 수정
- emailAuthApi.ts, googleAuthApi.ts에서 쿠키 기반 토큰 처리
- 로그아웃 시 요청 바디에 refreshToken 포함하지 않음
4. AuthManager 로직 개선
- 로그인 시 refreshToken을 빈 문자열로 저장 (쿠키로 관리)
- 로그아웃 시 클라이언트에서 refreshToken 추출 불필요
5. 테스트 코드 업데이트
- 모든 HTTP 클라이언트에 getCookies() 메서드 구현
- MSW 핸들러에서 쿠키 기반 응답 시뮬레이션
- 통합 테스트에서 쿠키 기반 인증 플로우 검증
## 📷 스크린샷

> 이미지


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭


### 📌 PR 진행 시 참고사항

- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)