### PR TITLE
[WQ-104] feat: 이메일 로그아웃 요청시 Authorization: Bearer {accessToken} 헤더 추가

### DIFF
--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -219,7 +219,6 @@ export class AuthManager {
       } else {
         // 타입 가드를 통해 error 속성에 안전하게 접근
         const errorMessage = 'error' in loginResponse ? loginResponse.error : '알 수 없는 오류';
-        console.log(`[AuthManager] ${this.provider.providerName} 로그인 실패:`, errorMessage);
       }
       
       return loginResponse;
@@ -305,10 +304,17 @@ export class AuthManager {
       const platform = this.config.platform || 'web';
       let logoutRequest = { ...request };
       
-      // 모바일 앱인 경우 저장된 refreshToken을 request에 추가
-      if (platform === 'app') {
-        const tokenResult = await this.tokenStore.getToken();
-        if (tokenResult.success && tokenResult.data?.refreshToken) {
+      // 저장된 토큰 가져오기
+      const tokenResult = await this.tokenStore.getToken();
+      
+      if (tokenResult.success && tokenResult.data) {
+        // 이메일 로그아웃인 경우에만 accessToken을 헤더로 전달
+        if (this.provider.providerName === 'email' && tokenResult.data.accessToken) {
+          logoutRequest.accessToken = tokenResult.data.accessToken;
+        }
+        
+        // 모바일 앱인 경우 저장된 refreshToken을 request에 추가
+        if (platform === 'app' && tokenResult.data.refreshToken) {
           logoutRequest.refreshToken = tokenResult.data.refreshToken;
         }
       }

--- a/src/network/emailAuthApi.ts
+++ b/src/network/emailAuthApi.ts
@@ -139,6 +139,7 @@ export async function loginByEmail(
 /**
  * 이메일 로그아웃 (플랫폼별 처리)
  * 웹: refreshToken은 쿠키로 전송, 모바일: refreshToken은 바디에 포함
+ * accessToken은 Authorization 헤더로 전송
  */
 export async function logoutByEmail(
   httpClient: HttpClient,
@@ -166,9 +167,16 @@ export async function logoutByEmail(
       }
     }
 
+    // 헤더 구성 (accessToken 포함)
+    const headers = createPlatformHeaders(platform);
+    if (request.accessToken) {
+      headers['Authorization'] = `Bearer ${request.accessToken}`;
+    }
+
     // 플랫폼별 로그아웃 요청
     const response = await makeRequestWithRetry(httpClient, config, config.endpoints.logout, {
       method: 'POST',
+      headers,
       // 웹: 쿠키는 브라우저가 자동으로 전송, 모바일: refreshToken을 바디에 포함
       body: requestBody
     });

--- a/src/providers/interfaces/dtos/auth.dto.ts
+++ b/src/providers/interfaces/dtos/auth.dto.ts
@@ -55,6 +55,7 @@ export interface LogoutRequest extends BaseRequest {
   // 모바일: refreshToken을 바디에 포함해서 전송
   refreshToken?: string;   // 모바일용 (앱에서는 바디에 포함)
   deviceId?: string;       // 모바일용 디바이스 ID (선택적)
+  accessToken?: string;    // Authorization 헤더로 전송 (이메일 로그아웃용)
 }
 
 // 로그아웃 응답 DTO


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close [WQ-104]


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- logoutByEmail(): 로그아웃시 access token 헤더에 넣어서 요청하도록 수정
```ts
const headers = createPlatformHeaders(platform);
   if (request.accessToken) {
     headers['Authorization'] = `Bearer ${request.accessToken}`;  // ✅
   }
```
## 📷 스크린샷

> 이미지


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭


### 📌 PR 진행 시 참고사항

- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)

[WQ-104]: https://growgrammers.atlassian.net/browse/WQ-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ