### PR TITLE
fix: 이메일 로그인 시 Authorization 헤더에서 토큰 추출 기능 추가

### DIFF
--- a/src/network/emailAuthApi.ts
+++ b/src/network/emailAuthApi.ts
@@ -128,7 +128,8 @@ export async function loginByEmail(
       body: requestBody
     });
 
-    const data = await handleHttpResponse<LoginApiResponse>(response, '로그인에 실패했습니다.');
+    // 이메일 로그인은 Authorization 헤더로 토큰을 받으므로 헤더에서 토큰 추출 옵션 사용
+    const data = await handleHttpResponse<LoginApiResponse>(response, '로그인에 실패했습니다.', true);
     return data;
 
   } catch (error) {


### PR DESCRIPTION
## 📝 작업 내용

이메일 로그인에서도 Authorization 헤더에서 토큰 추출하여 회원정보 띄울 수 있도록 수정했습니다. 
<img width="903" height="1080" alt="image" src="https://github.com/user-attachments/assets/87f3c947-827c-473c-b9e3-0c94beeaeae3" />
