### PR TITLE
[WQ-143] feat: 소셜 로그인 네이버, 카카오 확장

### DIFF
--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -30,7 +30,7 @@ export type IsAuthenticatedApiResponse = SuccessResponse<boolean> | ErrorRespons
 export type ClearResponse = SuccessResponse<void> | ErrorResponse;
 
 export interface AuthManagerConfig {
-  providerType?: 'email' | 'google' | 'kakao' | 'fake'; // 팩토리를 통한 Provider 생성 (권장)
+  providerType?: 'email' | 'google' | 'kakao' | 'naver' | 'fake'; // 팩토리를 통한 Provider 생성 (권장)
   provider?: AuthProvider; // 직접 Provider 인스턴스 주입 (테스트에 유리하나, 프로덕션에서는 DI/팩토리 레이어 통해 주입 권장)
   apiConfig: ApiConfig;
   httpClient: HttpClient;  // HttpClient를 필수로 추가
@@ -73,7 +73,7 @@ export class AuthManager {
     this.tokenStore = config.tokenStore || this.createTokenStoreFromType(config.tokenStoreType);
   }
 
-  private createProvider(providerType: 'email' | 'google' | 'kakao' | 'fake', apiConfig: ApiConfig, httpClient: HttpClient): AuthProvider {
+  private createProvider(providerType: 'email' | 'google' | 'kakao' | 'naver' | 'fake', apiConfig: ApiConfig, httpClient: HttpClient): AuthProvider {
     // Provider 팩토리 로직 (apiConfig 주입)
     const config = this.config.providerConfig || { timeout: 10000, retryCount: 3 }; // providerConfig 우선, 없으면 기본 설정
     const platform = this.config.platform || 'web'; // 플랫폼 기본값: 'web'

--- a/src/AuthManager.ts
+++ b/src/AuthManager.ts
@@ -30,7 +30,7 @@ export type IsAuthenticatedApiResponse = SuccessResponse<boolean> | ErrorRespons
 export type ClearResponse = SuccessResponse<void> | ErrorResponse;
 
 export interface AuthManagerConfig {
-  providerType?: 'email' | 'google' | 'fake'; // 팩토리를 통한 Provider 생성 (권장)
+  providerType?: 'email' | 'google' | 'kakao' | 'fake'; // 팩토리를 통한 Provider 생성 (권장)
   provider?: AuthProvider; // 직접 Provider 인스턴스 주입 (테스트에 유리하나, 프로덕션에서는 DI/팩토리 레이어 통해 주입 권장)
   apiConfig: ApiConfig;
   httpClient: HttpClient;  // HttpClient를 필수로 추가
@@ -73,7 +73,7 @@ export class AuthManager {
     this.tokenStore = config.tokenStore || this.createTokenStoreFromType(config.tokenStoreType);
   }
 
-  private createProvider(providerType: 'email' | 'google' | 'fake', apiConfig: ApiConfig, httpClient: HttpClient): AuthProvider {
+  private createProvider(providerType: 'email' | 'google' | 'kakao' | 'fake', apiConfig: ApiConfig, httpClient: HttpClient): AuthProvider {
     // Provider 팩토리 로직 (apiConfig 주입)
     const config = this.config.providerConfig || { timeout: 10000, retryCount: 3 }; // providerConfig 우선, 없으면 기본 설정
     const platform = this.config.platform || 'web'; // 플랫폼 기본값: 'web'

--- a/src/factories/AuthProviderFactory.ts
+++ b/src/factories/AuthProviderFactory.ts
@@ -1,6 +1,6 @@
 // 주어진 타입과 설정(config)에 따라 적절한 인증 제공자 인스턴스를 생성합니다.
 
-import { AuthProvider, AuthProviderConfig, GoogleAuthProviderConfig, EmailAuthProvider, GoogleAuthProvider } from '../providers';
+import { AuthProvider, AuthProviderConfig, GoogleAuthProviderConfig, KakaoAuthProviderConfig, EmailAuthProvider, GoogleAuthProvider, KakaoAuthProvider } from '../providers';
 import { AuthProviderType, ApiConfig, FactoryResult, FactoryErrorResponse, isFactorySuccess, isFactoryError, ClientPlatformType } from '../shared/types';
 import { HttpClient } from '../network/interfaces/HttpClient';
 import { createErrorResponse } from '../shared/utils/errorUtils';
@@ -23,7 +23,7 @@ export function isAuthProviderFactoryError(result: AuthProviderFactoryResult): r
 
 /**
  * 인증 제공자 타입과 설정을 받아서 해당하는 인증 제공자 인스턴스를 반환합니다.
- * @param type - 'email' | 'google' 등 인증 제공자 타입
+ * @param type - 'email' | 'google' | 'kakao' 등 인증 제공자 타입
  * @param config - 인증 제공자별 공통 설정 객체
  * @param httpClient - HTTP 클라이언트 인스턴스
  * @param apiConfig - API 설정 객체
@@ -50,6 +50,15 @@ export function createAuthProvider(
           );
         }
         return new GoogleAuthProvider(config, httpClient, apiConfig, platform);
+      case 'kakao':
+        // Kakao 제공자의 경우 KakaoAuthProviderConfig가 필요
+        if (!isKakaoAuthProviderConfig(config)) {
+          return createErrorResponse(
+            'Kakao 인증 제공자에는 kakaoClientId가 필요합니다.',
+            'Kakao 인증 제공자를 생성하려면 kakaoClientId 설정이 필요합니다.'
+          );
+        }
+        return new KakaoAuthProvider(config, httpClient, apiConfig, platform);
       default:
         return createErrorResponse(
           `지원하지 않는 인증 제공자입니다: ${type}`,
@@ -70,4 +79,11 @@ export function createAuthProvider(
  */
 function isGoogleAuthProviderConfig(config: AuthProviderConfig): config is GoogleAuthProviderConfig {
   return 'googleClientId' in config && typeof config.googleClientId === 'string';
+}
+
+/**
+ * 타입 가드: config가 KakaoAuthProviderConfig인지 확인
+ */
+function isKakaoAuthProviderConfig(config: AuthProviderConfig): config is KakaoAuthProviderConfig {
+  return 'kakaoClientId' in config && typeof config.kakaoClientId === 'string';
 }

--- a/src/factories/AuthProviderFactory.ts
+++ b/src/factories/AuthProviderFactory.ts
@@ -1,6 +1,6 @@
 // 주어진 타입과 설정(config)에 따라 적절한 인증 제공자 인스턴스를 생성합니다.
 
-import { AuthProvider, AuthProviderConfig, GoogleAuthProviderConfig, KakaoAuthProviderConfig, EmailAuthProvider, GoogleAuthProvider, KakaoAuthProvider } from '../providers';
+import { AuthProvider, AuthProviderConfig, GoogleAuthProviderConfig, KakaoAuthProviderConfig, NaverAuthProviderConfig, EmailAuthProvider, GoogleAuthProvider, KakaoAuthProvider, NaverAuthProvider } from '../providers';
 import { AuthProviderType, ApiConfig, FactoryResult, FactoryErrorResponse, isFactorySuccess, isFactoryError, ClientPlatformType } from '../shared/types';
 import { HttpClient } from '../network/interfaces/HttpClient';
 import { createErrorResponse } from '../shared/utils/errorUtils';
@@ -23,7 +23,7 @@ export function isAuthProviderFactoryError(result: AuthProviderFactoryResult): r
 
 /**
  * 인증 제공자 타입과 설정을 받아서 해당하는 인증 제공자 인스턴스를 반환합니다.
- * @param type - 'email' | 'google' | 'kakao' 등 인증 제공자 타입
+ * @param type - 'email' | 'google' | 'kakao' | 'naver' 등 인증 제공자 타입
  * @param config - 인증 제공자별 공통 설정 객체
  * @param httpClient - HTTP 클라이언트 인스턴스
  * @param apiConfig - API 설정 객체
@@ -59,6 +59,15 @@ export function createAuthProvider(
           );
         }
         return new KakaoAuthProvider(config, httpClient, apiConfig, platform);
+      case 'naver':
+        // Naver 제공자의 경우 NaverAuthProviderConfig가 필요
+        if (!isNaverAuthProviderConfig(config)) {
+          return createErrorResponse(
+            'Naver 인증 제공자에는 naverClientId가 필요합니다.',
+            'Naver 인증 제공자를 생성하려면 naverClientId 설정이 필요합니다.'
+          );
+        }
+        return new NaverAuthProvider(config, httpClient, apiConfig, platform);
       default:
         return createErrorResponse(
           `지원하지 않는 인증 제공자입니다: ${type}`,
@@ -86,4 +95,11 @@ function isGoogleAuthProviderConfig(config: AuthProviderConfig): config is Googl
  */
 function isKakaoAuthProviderConfig(config: AuthProviderConfig): config is KakaoAuthProviderConfig {
   return 'kakaoClientId' in config && typeof config.kakaoClientId === 'string';
+}
+
+/**
+ * 타입 가드: config가 NaverAuthProviderConfig인지 확인
+ */
+function isNaverAuthProviderConfig(config: AuthProviderConfig): config is NaverAuthProviderConfig {
+  return 'naverClientId' in config && typeof config.naverClientId === 'string';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ export {
   AuthProvider, 
   AuthProviderConfig,
   GoogleAuthProviderConfig,
-  KakaoAuthProviderConfig
+  KakaoAuthProviderConfig,
+  NaverAuthProviderConfig
 } from './providers';
 
 // DTOs
@@ -38,7 +39,7 @@ export type {
 } from './providers/interfaces/dtos/auth.dto';
 
 // 구현체들
-export { EmailAuthProvider, GoogleAuthProvider, KakaoAuthProvider } from './providers';
+export { EmailAuthProvider, GoogleAuthProvider, KakaoAuthProvider, NaverAuthProvider } from './providers';
 export { BaseAuthProvider } from './providers/base/BaseAuthProvider';
 
 // 토큰 저장소 관련

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ export { AuthManager } from './AuthManager';
 // 인터페이스들
 export { 
   AuthProvider, 
-  AuthProviderConfig
+  AuthProviderConfig,
+  GoogleAuthProviderConfig,
+  KakaoAuthProviderConfig
 } from './providers';
 
 // DTOs
@@ -36,7 +38,7 @@ export type {
 } from './providers/interfaces/dtos/auth.dto';
 
 // 구현체들
-export { EmailAuthProvider, GoogleAuthProvider } from './providers';
+export { EmailAuthProvider, GoogleAuthProvider, KakaoAuthProvider } from './providers';
 export { BaseAuthProvider } from './providers/base/BaseAuthProvider';
 
 // 토큰 저장소 관련

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -14,4 +14,5 @@ export {
   checkEmailServiceAvailability
 } from './emailAuthApi';
 
-export * from './googleAuthApi'; 
+export * from './googleAuthApi';
+export * from './kakaoAuthApi'; 

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -15,4 +15,5 @@ export {
 } from './emailAuthApi';
 
 export * from './googleAuthApi';
-export * from './kakaoAuthApi'; 
+export * from './kakaoAuthApi';
+export * from './naverAuthApi'; 

--- a/src/network/kakaoAuthApi.ts
+++ b/src/network/kakaoAuthApi.ts
@@ -1,0 +1,241 @@
+// Kakao OAuth 인증 API 구현
+import { ApiConfig, Token, UserInfo, ClientPlatformType } from '../shared/types';
+import { HttpClient } from './interfaces/HttpClient';
+import { 
+  LoginRequest, 
+  LogoutRequest, 
+  RefreshTokenRequest,
+  LoginApiResponse,
+  LogoutApiResponse,
+  RefreshTokenApiResponse,
+  TokenValidationApiResponse,
+  UserInfoApiResponse,
+  ServiceAvailabilityApiResponse,
+
+} from '../providers/interfaces/dtos/auth.dto';
+
+import { createErrorResponse, createValidationErrorResponse, createNetworkErrorResponse } from '../shared/utils/errorUtils';
+import { makeRequest, makeRequestWithRetry, handleHttpResponse, createToken, createUserInfo, createPlatformHeaders } from './utils/httpUtils';
+
+/**
+ * Kakao OAuth 로그인 (플랫폼별 처리)
+ */
+export async function loginByKakao(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  request: LoginRequest,
+  platform: ClientPlatformType = 'web'
+): Promise<LoginApiResponse> {
+  try {
+    // Kakao 로그인 요청 타입 가드
+    if (!('authCode' in request)) {
+      return createErrorResponse('카카오 로그인 요청이 아닙니다.');
+    }
+
+    // 카카오 인증 코드 검증
+    if (!request.authCode) {
+      return createValidationErrorResponse('카카오 인증 코드');
+    }
+
+    // 플랫폼별 요청 바디 구성
+    const requestBody: any = { authCode: request.authCode };
+    
+    // PKCE code verifier 추가 (웹 플랫폼에서 사용)
+    if ('codeVerifier' in request && request.codeVerifier) {
+      requestBody.codeVerifier = request.codeVerifier;
+    }
+    
+    // 모바일의 경우 deviceId 추가
+    if (platform === 'app' && 'deviceId' in request && request.deviceId) {
+      requestBody.deviceId = request.deviceId;
+    }
+
+    const response = await makeRequestWithRetry(
+      httpClient, 
+      config, 
+      config.endpoints.kakaoLogin,
+      {
+        method: 'POST',
+        headers: createPlatformHeaders(platform),
+        body: requestBody
+      }
+    );
+
+    const data = await handleHttpResponse<LoginApiResponse>(response, '카카오 로그인에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+export async function logoutByKakao(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  request: LogoutRequest,
+  platform: ClientPlatformType = 'web'
+): Promise<LogoutApiResponse> {
+  try {
+    // 요청 바디 구성 (플랫폼별 처리)
+    let requestBody: any = undefined;
+    
+    if (platform === 'app') {
+      // 모바일: refreshToken과 deviceId를 바디에 포함
+      requestBody = {};
+      if (request.refreshToken) {
+        requestBody.refreshToken = request.refreshToken;
+      }
+      if (request.deviceId) {
+        requestBody.deviceId = request.deviceId;
+      }
+    } else {
+      // 웹: deviceId만 포함 (refreshToken은 쿠키로 전송)
+      if (request.deviceId) {
+        requestBody = { deviceId: request.deviceId };
+      }
+    }
+
+    // 플랫폼별 카카오 로그아웃 요청
+    const response = await makeRequestWithRetry(
+      httpClient, 
+      config, 
+      config.endpoints.kakaoLogout,
+      {
+        method: 'POST',
+        // 웹: 쿠키는 브라우저가 자동으로 전송, 모바일: refreshToken을 바디에 포함
+        body: requestBody
+      }
+    );
+
+    const data = await handleHttpResponse<LogoutApiResponse>(response, '카카오 로그아웃에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+export async function refreshTokenByKakao(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  request: RefreshTokenRequest,
+  platform: ClientPlatformType = 'web'
+): Promise<RefreshTokenApiResponse> {
+  try {
+    let requestBody: any = {};
+
+    // 모바일의 경우 refreshToken과 deviceId를 바디에 포함
+    if (platform === 'app') {
+      if (!request.refreshToken) {
+        return createErrorResponse('모바일에서는 refreshToken이 필요합니다.');
+      }
+      requestBody.refreshToken = request.refreshToken;
+      
+      if (request.deviceId) {
+        requestBody.deviceId = request.deviceId;
+      }
+    }
+
+    const response = await makeRequestWithRetry(
+      httpClient, 
+      config, 
+      config.endpoints.kakaoRefresh,
+      {
+        method: 'POST',
+        headers: createPlatformHeaders(platform),
+        body: platform === 'app' ? requestBody : undefined // 웹은 body 없음 (쿠키 사용)
+      }
+    );
+
+    const data = await handleHttpResponse<RefreshTokenApiResponse>(response, '카카오 토큰 갱신에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+/**
+ * Kakao OAuth 토큰 검증
+ * 우리 백엔드 OAuth 엔드포인트를 통해 토큰 검증
+ */
+export async function validateTokenByKakao(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  token: Token
+): Promise<TokenValidationApiResponse> {
+  try {
+    if (!token.accessToken) {
+      return createValidationErrorResponse('액세스 토큰');
+    }
+
+    const response = await makeRequestWithRetry(
+      httpClient,
+      config,
+      config.endpoints.kakaoValidate, // /api/auth/kakao/validate
+      {
+        method: 'POST',
+        body: { accessToken: token.accessToken }
+      }
+    );
+
+    const data = await handleHttpResponse<TokenValidationApiResponse>(response, 'Kakao 토큰 검증에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+/**
+ * Kakao OAuth 사용자 정보 조회
+ * 우리 백엔드 OAuth 엔드포인트를 통해 사용자 정보 조회
+ */
+export async function getUserInfoByKakao(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  token: Token
+): Promise<UserInfoApiResponse> {
+  try {
+    if (!token.accessToken) {
+      return createValidationErrorResponse('액세스 토큰');
+    }
+
+    const response = await makeRequestWithRetry(
+      httpClient,
+      config,
+      config.endpoints.kakaoUserinfo, // /api/auth/kakao/userinfo
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token.accessToken}`
+        }
+      }
+    );
+
+    const data = await handleHttpResponse<UserInfoApiResponse>(response, 'Kakao 사용자 정보 조회에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+/**
+ * Kakao OAuth 서비스 가용성 확인 (v2.0에서 구현 예정)
+ */
+export async function checkKakaoServiceAvailability(
+  httpClient: HttpClient,
+  config: ApiConfig
+): Promise<ServiceAvailabilityApiResponse> {
+  try {
+    const response = await makeRequest(httpClient, config, config.endpoints.health, {
+      method: 'GET'
+    });
+
+    const data = await handleHttpResponse<ServiceAvailabilityApiResponse>(response, 'Kakao 서비스 가용성 확인에 실패했습니다.');
+    return data;
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}

--- a/src/network/naverAuthApi.ts
+++ b/src/network/naverAuthApi.ts
@@ -1,0 +1,241 @@
+// Naver OAuth 인증 API 구현
+import { ApiConfig, Token, UserInfo, ClientPlatformType } from '../shared/types';
+import { HttpClient } from './interfaces/HttpClient';
+import { 
+  LoginRequest, 
+  LogoutRequest, 
+  RefreshTokenRequest,
+  LoginApiResponse,
+  LogoutApiResponse,
+  RefreshTokenApiResponse,
+  TokenValidationApiResponse,
+  UserInfoApiResponse,
+  ServiceAvailabilityApiResponse,
+
+} from '../providers/interfaces/dtos/auth.dto';
+
+import { createErrorResponse, createValidationErrorResponse, createNetworkErrorResponse } from '../shared/utils/errorUtils';
+import { makeRequest, makeRequestWithRetry, handleHttpResponse, createToken, createUserInfo, createPlatformHeaders } from './utils/httpUtils';
+
+/**
+ * Naver OAuth 로그인 (플랫폼별 처리)
+ */
+export async function loginByNaver(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  request: LoginRequest,
+  platform: ClientPlatformType = 'web'
+): Promise<LoginApiResponse> {
+  try {
+    // Naver 로그인 요청 타입 가드
+    if (!('authCode' in request)) {
+      return createErrorResponse('네이버 로그인 요청이 아닙니다.');
+    }
+
+    // 네이버 인증 코드 검증
+    if (!request.authCode) {
+      return createValidationErrorResponse('네이버 인증 코드');
+    }
+
+    // 플랫폼별 요청 바디 구성
+    const requestBody: any = { authCode: request.authCode };
+    
+    // PKCE code verifier 추가 (웹 플랫폼에서 사용)
+    if ('codeVerifier' in request && request.codeVerifier) {
+      requestBody.codeVerifier = request.codeVerifier;
+    }
+    
+    // 모바일의 경우 deviceId 추가
+    if (platform === 'app' && 'deviceId' in request && request.deviceId) {
+      requestBody.deviceId = request.deviceId;
+    }
+
+    const response = await makeRequestWithRetry(
+      httpClient, 
+      config, 
+      config.endpoints.naverLogin,
+      {
+        method: 'POST',
+        headers: createPlatformHeaders(platform),
+        body: requestBody
+      }
+    );
+
+    const data = await handleHttpResponse<LoginApiResponse>(response, '네이버 로그인에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+export async function logoutByNaver(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  request: LogoutRequest,
+  platform: ClientPlatformType = 'web'
+): Promise<LogoutApiResponse> {
+  try {
+    // 요청 바디 구성 (플랫폼별 처리)
+    let requestBody: any = undefined;
+    
+    if (platform === 'app') {
+      // 모바일: refreshToken과 deviceId를 바디에 포함
+      requestBody = {};
+      if (request.refreshToken) {
+        requestBody.refreshToken = request.refreshToken;
+      }
+      if (request.deviceId) {
+        requestBody.deviceId = request.deviceId;
+      }
+    } else {
+      // 웹: deviceId만 포함 (refreshToken은 쿠키로 전송)
+      if (request.deviceId) {
+        requestBody = { deviceId: request.deviceId };
+      }
+    }
+
+    // 플랫폼별 네이버 로그아웃 요청
+    const response = await makeRequestWithRetry(
+      httpClient, 
+      config, 
+      config.endpoints.naverLogout,
+      {
+        method: 'POST',
+        // 웹: 쿠키는 브라우저가 자동으로 전송, 모바일: refreshToken을 바디에 포함
+        body: requestBody
+      }
+    );
+
+    const data = await handleHttpResponse<LogoutApiResponse>(response, '네이버 로그아웃에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+export async function refreshTokenByNaver(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  request: RefreshTokenRequest,
+  platform: ClientPlatformType = 'web'
+): Promise<RefreshTokenApiResponse> {
+  try {
+    let requestBody: any = {};
+
+    // 모바일의 경우 refreshToken과 deviceId를 바디에 포함
+    if (platform === 'app') {
+      if (!request.refreshToken) {
+        return createErrorResponse('모바일에서는 refreshToken이 필요합니다.');
+      }
+      requestBody.refreshToken = request.refreshToken;
+      
+      if (request.deviceId) {
+        requestBody.deviceId = request.deviceId;
+      }
+    }
+
+    const response = await makeRequestWithRetry(
+      httpClient, 
+      config, 
+      config.endpoints.naverRefresh,
+      {
+        method: 'POST',
+        headers: createPlatformHeaders(platform),
+        body: platform === 'app' ? requestBody : undefined // 웹은 body 없음 (쿠키 사용)
+      }
+    );
+
+    const data = await handleHttpResponse<RefreshTokenApiResponse>(response, '네이버 토큰 갱신에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+/**
+ * Naver OAuth 토큰 검증
+ * 우리 백엔드 OAuth 엔드포인트를 통해 토큰 검증
+ */
+export async function validateTokenByNaver(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  token: Token
+): Promise<TokenValidationApiResponse> {
+  try {
+    if (!token.accessToken) {
+      return createValidationErrorResponse('액세스 토큰');
+    }
+
+    const response = await makeRequestWithRetry(
+      httpClient,
+      config,
+      config.endpoints.naverValidate, // /api/auth/naver/validate
+      {
+        method: 'POST',
+        body: { accessToken: token.accessToken }
+      }
+    );
+
+    const data = await handleHttpResponse<TokenValidationApiResponse>(response, 'Naver 토큰 검증에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+/**
+ * Naver OAuth 사용자 정보 조회
+ * 우리 백엔드 OAuth 엔드포인트를 통해 사용자 정보 조회
+ */
+export async function getUserInfoByNaver(
+  httpClient: HttpClient,
+  config: ApiConfig,
+  token: Token
+): Promise<UserInfoApiResponse> {
+  try {
+    if (!token.accessToken) {
+      return createValidationErrorResponse('액세스 토큰');
+    }
+
+    const response = await makeRequestWithRetry(
+      httpClient,
+      config,
+      config.endpoints.naverUserinfo, // /api/auth/naver/userinfo
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token.accessToken}`
+        }
+      }
+    );
+
+    const data = await handleHttpResponse<UserInfoApiResponse>(response, 'Naver 사용자 정보 조회에 실패했습니다.');
+    return data;
+
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}
+
+/**
+ * Naver OAuth 서비스 가용성 확인 (v2.0에서 구현 예정)
+ */
+export async function checkNaverServiceAvailability(
+  httpClient: HttpClient,
+  config: ApiConfig
+): Promise<ServiceAvailabilityApiResponse> {
+  try {
+    const response = await makeRequest(httpClient, config, config.endpoints.health, {
+      method: 'GET'
+    });
+
+    const data = await handleHttpResponse<ServiceAvailabilityApiResponse>(response, 'Naver 서비스 가용성 확인에 실패했습니다.');
+    return data;
+  } catch (error) {
+    return createNetworkErrorResponse();
+  }
+}

--- a/src/providers/implementations/KakaoAuthProvider.ts
+++ b/src/providers/implementations/KakaoAuthProvider.ts
@@ -1,0 +1,95 @@
+// Kakao OAuth 인증 제공자 구현
+import { HttpClient } from '../../network/interfaces/HttpClient';
+import { AuthProviderConfig, KakaoAuthProviderConfig } from '../interfaces/config/auth-config';
+import { BaseAuthProvider } from '../base/BaseAuthProvider';
+import { Token, UserInfo, BaseResponse, ApiConfig, ClientPlatformType } from '../../shared/types';
+import {
+  LoginRequest,
+  LogoutRequest,
+  RefreshTokenRequest,
+  LoginApiResponse,
+  LogoutApiResponse,
+  RefreshTokenApiResponse,
+  TokenValidationApiResponse,
+  UserInfoApiResponse,
+  ServiceAvailabilityApiResponse,
+  LoginResponseData
+} from '../interfaces/dtos/auth.dto';
+import { ILoginProvider } from '../interfaces';
+import {
+  loginByKakao,
+  logoutByKakao,
+  refreshTokenByKakao
+} from '../../network';
+import { 
+  checkKakaoServiceAvailability,
+  validateTokenByKakao,
+  getUserInfoByKakao
+} from '../../network/kakaoAuthApi';
+
+export class KakaoAuthProvider extends BaseAuthProvider implements ILoginProvider {
+  readonly providerName = 'kakao' as const;
+  readonly config: KakaoAuthProviderConfig;
+  private httpClient: HttpClient;
+  private apiConfig: ApiConfig;
+  private platform: ClientPlatformType;
+
+  constructor(config: KakaoAuthProviderConfig, httpClient: HttpClient, apiConfig: ApiConfig, platform: ClientPlatformType = 'web') {
+    super();
+    this.config = config;
+    this.httpClient = httpClient;
+    this.apiConfig = apiConfig;
+    this.platform = platform;
+  }
+
+  async login(request: LoginRequest): Promise<LoginApiResponse> {
+    // OAuth 로그인 요청 타입 가드
+    if (!('authCode' in request)) {
+      return this.createErrorResponse(
+        'OAuth 로그인 요청이 아닙니다.',
+        'KakaoAuthProvider는 OAuth 로그인 요청만 지원합니다.'
+      );
+    }
+
+    // authCode를 직접 사용하여 백엔드 API 호출
+    const apiResponse = await loginByKakao(this.httpClient, this.apiConfig, request, this.platform);
+    
+    // 백엔드 응답을 그대로 반환 (성공/실패 모두)
+    return apiResponse;
+  }
+
+  async logout(request: LogoutRequest): Promise<LogoutApiResponse> {
+    const apiResponse = await logoutByKakao(this.httpClient, this.apiConfig, request, this.platform);
+    
+    // 백엔드 응답을 그대로 반환 (성공/실패 모두)
+    return apiResponse;
+  }
+
+  async refreshToken(request: RefreshTokenRequest): Promise<RefreshTokenApiResponse> {
+    const apiResponse = await refreshTokenByKakao(this.httpClient, this.apiConfig, request, this.platform);
+    
+    // 백엔드 응답을 그대로 반환 (성공/실패 모두)
+    return apiResponse;
+  }
+
+  async validateToken(token: Token): Promise<TokenValidationApiResponse> {
+    // 백엔드 OAuth 엔드포인트를 통해 토큰 검증
+    return validateTokenByKakao(this.httpClient, this.apiConfig, token);
+  }
+
+  async getUserInfo(token: Token): Promise<UserInfoApiResponse> {
+    // 백엔드 OAuth 엔드포인트를 통해 사용자 정보 조회
+    return getUserInfoByKakao(this.httpClient, this.apiConfig, token);
+  }
+
+  async isAvailable(): Promise<ServiceAvailabilityApiResponse> {
+    try {
+      return await checkKakaoServiceAvailability(this.httpClient, this.apiConfig);
+    } catch (error) {
+      return this.createErrorResponse(
+        'Kakao 서비스 가용성 확인 중 오류가 발생했습니다.',
+        '서비스 상태 확인 중 오류가 발생했습니다.'
+      );
+    }
+  }
+}

--- a/src/providers/implementations/NaverAuthProvider.ts
+++ b/src/providers/implementations/NaverAuthProvider.ts
@@ -1,0 +1,95 @@
+// Naver OAuth 인증 제공자 구현
+import { HttpClient } from '../../network/interfaces/HttpClient';
+import { AuthProviderConfig, NaverAuthProviderConfig } from '../interfaces/config/auth-config';
+import { BaseAuthProvider } from '../base/BaseAuthProvider';
+import { Token, UserInfo, BaseResponse, ApiConfig, ClientPlatformType } from '../../shared/types';
+import {
+  LoginRequest,
+  LogoutRequest,
+  RefreshTokenRequest,
+  LoginApiResponse,
+  LogoutApiResponse,
+  RefreshTokenApiResponse,
+  TokenValidationApiResponse,
+  UserInfoApiResponse,
+  ServiceAvailabilityApiResponse,
+  LoginResponseData
+} from '../interfaces/dtos/auth.dto';
+import { ILoginProvider } from '../interfaces';
+import {
+  loginByNaver,
+  logoutByNaver,
+  refreshTokenByNaver
+} from '../../network';
+import { 
+  checkNaverServiceAvailability,
+  validateTokenByNaver,
+  getUserInfoByNaver
+} from '../../network/naverAuthApi';
+
+export class NaverAuthProvider extends BaseAuthProvider implements ILoginProvider {
+  readonly providerName = 'naver' as const;
+  readonly config: NaverAuthProviderConfig;
+  private httpClient: HttpClient;
+  private apiConfig: ApiConfig;
+  private platform: ClientPlatformType;
+
+  constructor(config: NaverAuthProviderConfig, httpClient: HttpClient, apiConfig: ApiConfig, platform: ClientPlatformType = 'web') {
+    super();
+    this.config = config;
+    this.httpClient = httpClient;
+    this.apiConfig = apiConfig;
+    this.platform = platform;
+  }
+
+  async login(request: LoginRequest): Promise<LoginApiResponse> {
+    // OAuth 로그인 요청 타입 가드
+    if (!('authCode' in request)) {
+      return this.createErrorResponse(
+        'OAuth 로그인 요청이 아닙니다.',
+        'NaverAuthProvider는 OAuth 로그인 요청만 지원합니다.'
+      );
+    }
+
+    // authCode를 직접 사용하여 백엔드 API 호출
+    const apiResponse = await loginByNaver(this.httpClient, this.apiConfig, request, this.platform);
+    
+    // 백엔드 응답을 그대로 반환 (성공/실패 모두)
+    return apiResponse;
+  }
+
+  async logout(request: LogoutRequest): Promise<LogoutApiResponse> {
+    const apiResponse = await logoutByNaver(this.httpClient, this.apiConfig, request, this.platform);
+    
+    // 백엔드 응답을 그대로 반환 (성공/실패 모두)
+    return apiResponse;
+  }
+
+  async refreshToken(request: RefreshTokenRequest): Promise<RefreshTokenApiResponse> {
+    const apiResponse = await refreshTokenByNaver(this.httpClient, this.apiConfig, request, this.platform);
+    
+    // 백엔드 응답을 그대로 반환 (성공/실패 모두)
+    return apiResponse;
+  }
+
+  async validateToken(token: Token): Promise<TokenValidationApiResponse> {
+    // 백엔드 OAuth 엔드포인트를 통해 토큰 검증
+    return validateTokenByNaver(this.httpClient, this.apiConfig, token);
+  }
+
+  async getUserInfo(token: Token): Promise<UserInfoApiResponse> {
+    // 백엔드 OAuth 엔드포인트를 통해 사용자 정보 조회
+    return getUserInfoByNaver(this.httpClient, this.apiConfig, token);
+  }
+
+  async isAvailable(): Promise<ServiceAvailabilityApiResponse> {
+    try {
+      return await checkNaverServiceAvailability(this.httpClient, this.apiConfig);
+    } catch (error) {
+      return this.createErrorResponse(
+        'Naver 서비스 가용성 확인 중 오류가 발생했습니다.',
+        '서비스 상태 확인 중 오류가 발생했습니다.'
+      );
+    }
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -6,3 +6,4 @@ export * from './base/BaseAuthProvider';
 export * from './implementations/EmailAuthProvider';
 export * from './implementations/GoogleAuthProvider';
 export * from './implementations/KakaoAuthProvider';
+export * from './implementations/NaverAuthProvider';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,3 +5,4 @@ export * from './interfaces/config/auth-config';
 export * from './base/BaseAuthProvider';
 export * from './implementations/EmailAuthProvider';
 export * from './implementations/GoogleAuthProvider';
+export * from './implementations/KakaoAuthProvider';

--- a/src/providers/interfaces/config/auth-config.ts
+++ b/src/providers/interfaces/config/auth-config.ts
@@ -11,4 +11,10 @@ export interface GoogleAuthProviderConfig extends AuthProviderConfig {
   googleClientId: string;
   googleClientSecret?: string; // 서버 사이드에서만 필요
   googleProjectId?: string;
+}
+
+// Kakao OAuth 전용 설정 인터페이스
+export interface KakaoAuthProviderConfig extends AuthProviderConfig {
+  kakaoClientId: string;
+  kakaoClientSecret?: string; // 서버 사이드에서만 필요
 } 

--- a/src/providers/interfaces/config/auth-config.ts
+++ b/src/providers/interfaces/config/auth-config.ts
@@ -17,4 +17,10 @@ export interface GoogleAuthProviderConfig extends AuthProviderConfig {
 export interface KakaoAuthProviderConfig extends AuthProviderConfig {
   kakaoClientId: string;
   kakaoClientSecret?: string; // 서버 사이드에서만 필요
+}
+
+// Naver OAuth 전용 설정 인터페이스
+export interface NaverAuthProviderConfig extends AuthProviderConfig {
+  naverClientId: string;
+  naverClientSecret?: string; // 서버 사이드에서만 필요
 } 

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -18,6 +18,12 @@ export interface ApiEndpoints {
   googleRefresh: string;   // 구글 토큰 갱신
   googleValidate: string;  // 구글 토큰 검증
   googleUserinfo: string;  // 구글 사용자 정보 조회
+  // 카카오 인증
+  kakaoLogin: string;      // 카카오 로그인
+  kakaoLogout: string;     // 카카오 로그아웃
+  kakaoRefresh: string;    // 카카오 토큰 갱신
+  kakaoValidate: string;   // 카카오 토큰 검증
+  kakaoUserinfo: string;   // 카카오 사용자 정보 조회
   // 공통
   validate: string;
   me: string;

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -24,6 +24,12 @@ export interface ApiEndpoints {
   kakaoRefresh: string;    // 카카오 토큰 갱신
   kakaoValidate: string;   // 카카오 토큰 검증
   kakaoUserinfo: string;   // 카카오 사용자 정보 조회
+  // 네이버 인증
+  naverLogin: string;      // 네이버 로그인
+  naverLogout: string;     // 네이버 로그아웃
+  naverRefresh: string;    // 네이버 토큰 갱신
+  naverValidate: string;   // 네이버 토큰 검증
+  naverUserinfo: string;   // 네이버 사용자 정보 조회
   // 공통
   validate: string;
   me: string;

--- a/src/shared/types/literals.ts
+++ b/src/shared/types/literals.ts
@@ -2,7 +2,7 @@
 // shared/types/literals.ts
 
 // 인증 제공자 타입 (순환 참조 방지를 위해 별도 파일로 분리)
-export type AuthProviderType = 'email' | 'google' | 'fake';
+export type AuthProviderType = 'email' | 'google' | 'kakao' | 'fake';
 
 // 클라이언트 플랫폼 타입
 export type ClientPlatformType = 'web' | 'app' | 'react-native';

--- a/src/shared/types/literals.ts
+++ b/src/shared/types/literals.ts
@@ -2,7 +2,7 @@
 // shared/types/literals.ts
 
 // 인증 제공자 타입 (순환 참조 방지를 위해 별도 파일로 분리)
-export type AuthProviderType = 'email' | 'google' | 'kakao' | 'fake';
+export type AuthProviderType = 'email' | 'google' | 'kakao' | 'naver' | 'fake';
 
 // 클라이언트 플랫폼 타입
 export type ClientPlatformType = 'web' | 'app' | 'react-native';

--- a/test/unit/kakao-auth-provider.test.ts
+++ b/test/unit/kakao-auth-provider.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { KakaoAuthProvider } from '../../src/providers/implementations/KakaoAuthProvider';
+import { KakaoAuthProviderConfig } from '../../src/providers/interfaces/config/auth-config';
+import { FakeHttpClient } from '../mocks/FakeHttpClient';
+import { Token } from '../../src/shared/types';
+
+// Kakao Auth API 모킹
+vi.mock('../../src/network/kakaoAuthApi', () => ({
+  validateTokenByKakao: vi.fn(),
+  getUserInfoByKakao: vi.fn(),
+  checkKakaoServiceAvailability: vi.fn()
+}));
+
+// Network 모듈 모킹 (loginByKakao, logoutByKakao, refreshTokenByKakao가 여기서 export됨)
+vi.mock('../../src/network', () => ({
+  loginByKakao: vi.fn(),
+  logoutByKakao: vi.fn(),
+  refreshTokenByKakao: vi.fn()
+}));
+
+describe('KakaoAuthProvider', () => {
+  let kakaoProvider: KakaoAuthProvider;
+  let mockHttpClient: FakeHttpClient;
+  let mockApiConfig: any;
+  let mockConfig: KakaoAuthProviderConfig;
+
+  beforeEach(() => {
+    mockHttpClient = new FakeHttpClient();
+    mockApiConfig = {
+      apiBaseUrl: 'https://api.example.com',
+      endpoints: {
+        kakaoLogin: '/auth/kakao/login',
+        kakaoLogout: '/auth/kakao/logout',
+        kakaoRefresh: '/auth/kakao/refresh',
+        health: '/health' // Added health endpoint for isAvailable test
+      }
+    };
+    mockConfig = {
+      kakaoClientId: 'test-kakao-client-id',
+      timeout: 10000,
+      retryCount: 3
+    };
+
+    kakaoProvider = new KakaoAuthProvider(mockConfig, mockHttpClient, mockApiConfig);
+  });
+
+  describe('validateToken', () => {
+    it('액세스 토큰이 없으면 에러를 반환해야 한다', async () => {
+      const { validateTokenByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(validateTokenByKakao).mockResolvedValue({
+        success: false,
+        error: '토큰 검증을 위해 액세스 토큰이 필요합니다.',
+        message: '액세스 토큰이 필요합니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: '',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await kakaoProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('토큰 검증을 위해 액세스 토큰이 필요합니다.');
+        expect(result.message).toBe('액세스 토큰이 필요합니다.');
+      }
+    });
+
+    it('액세스 토큰이 null이면 에러를 반환해야 한다', async () => {
+      const { validateTokenByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(validateTokenByKakao).mockResolvedValue({
+        success: false,
+        error: '토큰 검증을 위해 액세스 토큰이 필요합니다.',
+        message: '액세스 토큰이 필요합니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: null as any,
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await kakaoProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('토큰 검증을 위해 액세스 토큰이 필요합니다.');
+      }
+    });
+
+    it('Kakao 토큰 검증이 실패하면 에러를 반환해야 한다', async () => {
+      const { validateTokenByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(validateTokenByKakao).mockResolvedValue({
+        success: false,
+        error: '제공된 토큰이 유효하지 않거나 만료되었습니다.',
+        message: 'Kakao 토큰 검증에 실패했습니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await kakaoProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('제공된 토큰이 유효하지 않거나 만료되었습니다.');
+        expect(result.message).toBe('Kakao 토큰 검증에 실패했습니다.');
+      }
+    });
+
+    it('이메일이 인증되지 않았으면 에러를 반환해야 한다', async () => {
+      const { validateTokenByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(validateTokenByKakao).mockResolvedValue({
+        success: false,
+        error: 'Kakao 계정의 이메일 인증이 필요합니다.',
+        message: '이메일이 인증되지 않았습니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await kakaoProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('Kakao 계정의 이메일 인증이 필요합니다.');
+        expect(result.message).toBe('이메일이 인증되지 않았습니다.');
+      }
+    });
+
+    it('토큰 검증이 성공하면 성공 응답을 반환해야 한다', async () => {
+      const { validateTokenByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(validateTokenByKakao).mockResolvedValue({
+        success: true,
+        message: 'Kakao 토큰 검증이 성공했습니다.',
+        data: true
+      });
+
+      const token: Token = {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await kakaoProvider.validateToken(token);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Kakao 토큰 검증이 성공했습니다.');
+        expect(result.data).toBe(true); // TokenValidationResponse는 boolean을 반환
+      }
+    });
+
+    it('예외가 발생하면 에러 응답을 반환해야 한다', async () => {
+      const { validateTokenByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(validateTokenByKakao).mockResolvedValue({
+        success: false,
+        error: '토큰 검증 과정에서 예상치 못한 오류가 발생했습니다.',
+        message: 'Kakao 토큰 검증 중 오류가 발생했습니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await kakaoProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('토큰 검증 과정에서 예상치 못한 오류가 발생했습니다.');
+        expect(result.message).toBe('Kakao 토큰 검증 중 오류가 발생했습니다.');
+      }
+    });
+  });
+
+  describe('getUserInfo', () => {
+    it('액세스 토큰이 없으면 에러를 반환해야 한다', async () => {
+      const { getUserInfoByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(getUserInfoByKakao).mockResolvedValue({
+        success: false,
+        error: '사용자 정보 조회를 위해 액세스 토큰이 필요합니다.',
+        message: '액세스 토큰이 필요합니다.',
+        data: null
+      });
+
+      const token: Token = { accessToken: '', refreshToken: 'r', expiredAt: Date.now() + 1000 };
+      const result = await kakaoProvider.getUserInfo(token);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('사용자 정보 조회를 위해 액세스 토큰이 필요합니다.');
+        expect(result.message).toBe('액세스 토큰이 필요합니다.');
+      }
+    });
+
+    it('토큰이 유효하지 않으면 에러를 반환해야 한다', async () => {
+      const { getUserInfoByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(getUserInfoByKakao).mockResolvedValue({
+        success: false,
+        error: '제공된 토큰이 유효하지 않거나 만료되었습니다.',
+        message: 'Kakao 사용자 정보 조회에 실패했습니다.',
+        data: null
+      });
+      const token: Token = { accessToken: 'x', refreshToken: 'r', expiredAt: Date.now() + 1000 };
+      const result = await kakaoProvider.getUserInfo(token);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('제공된 토큰이 유효하지 않거나 만료되었습니다.');
+        expect(result.message).toBe('Kakao 사용자 정보 조회에 실패했습니다.');
+      }
+    });
+
+    it('이메일이 인증되지 않으면 에러를 반환해야 한다', async () => {
+      const { getUserInfoByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(getUserInfoByKakao).mockResolvedValue({
+        success: false,
+        error: 'Kakao 계정의 이메일 인증이 필요합니다.',
+        message: '이메일이 인증되지 않았습니다.',
+        data: null
+      });
+      const token: Token = { accessToken: 'x', refreshToken: 'r', expiredAt: Date.now() + 1000 };
+      const result = await kakaoProvider.getUserInfo(token);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('Kakao 계정의 이메일 인증이 필요합니다.');
+        expect(result.message).toBe('이메일이 인증되지 않았습니다.');
+      }
+    });
+
+    it('정상 조회 시 사용자 정보를 반환해야 한다', async () => {
+      const { getUserInfoByKakao } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(getUserInfoByKakao).mockResolvedValue({
+        success: true,
+        message: 'Kakao 사용자 정보 조회가 성공했습니다.',
+        data: { id: 'u1', email: 'a@b.com', nickname: 'A', provider: 'kakao' }
+      });
+      const token: Token = { accessToken: 'x', refreshToken: 'r', expiredAt: Date.now() + 1000 };
+      const result = await kakaoProvider.getUserInfo(token);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Kakao 사용자 정보 조회가 성공했습니다.');
+        expect(result.data).toEqual({ id: 'u1', email: 'a@b.com', nickname: 'A', provider: 'kakao' });
+      }
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('헬스 체크가 성공하면 true를 반환해야 한다', async () => {
+      const { checkKakaoServiceAvailability } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(checkKakaoServiceAvailability).mockResolvedValue({
+        success: true,
+        message: 'Kakao 서비스가 정상입니다.',
+        data: true
+      });
+
+      const result = await kakaoProvider.isAvailable();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(true);
+      }
+    });
+
+    it('헬스 체크가 실패하면 에러를 반환해야 한다', async () => {
+      const { checkKakaoServiceAvailability } = await import('../../src/network/kakaoAuthApi');
+      vi.mocked(checkKakaoServiceAvailability).mockResolvedValue({
+        success: false,
+        error: 'Kakao 서비스가 사용 불가능합니다.',
+        message: '서비스 점검 중입니다.',
+        data: null
+      });
+
+      const result = await kakaoProvider.isAvailable();
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('login', () => {
+    it('OAuth 로그인 요청이 아니면 에러를 반환해야 한다', async () => {
+      // Email 로그인 요청 형태로 테스트
+      const invalidRequest = {
+        email: 'test@example.com',
+        password: 'password123'
+      } as any;
+
+      const result = await kakaoProvider.login(invalidRequest);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('KakaoAuthProvider는 OAuth 로그인 요청만 지원합니다.');
+        expect(result.message).toBe('OAuth 로그인 요청이 아닙니다.');
+      }
+    });
+
+    it('authCode가 있는 OAuth 요청은 정상 처리해야 한다', async () => {
+      const { loginByKakao } = await import('../../src/network');
+      vi.mocked(loginByKakao).mockResolvedValue({
+        success: true,
+        message: 'Kakao 로그인이 성공했습니다.',
+        data: {
+          token: {
+            accessToken: 'kakao-access-token',
+            refreshToken: 'kakao-refresh-token',
+            expiredAt: Date.now() + 3600000
+          },
+          user: {
+            id: 'kakao-user-1',
+            email: 'test@kakao.com',
+            nickname: 'Kakao User',
+            provider: 'kakao'
+          }
+        }
+      });
+
+      const oauthRequest = {
+        authCode: 'kakao-auth-code-123',
+        codeVerifier: 'code-verifier'
+      };
+
+      const result = await kakaoProvider.login(oauthRequest);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Kakao 로그인이 성공했습니다.');
+        expect(result.data.user.provider).toBe('kakao');
+      }
+    });
+  });
+
+  describe('logout', () => {
+    it('로그아웃 요청을 정상 처리해야 한다', async () => {
+      const { logoutByKakao } = await import('../../src/network');
+      vi.mocked(logoutByKakao).mockResolvedValue({
+        success: true,
+        message: 'Kakao 로그아웃이 성공했습니다.',
+        data: null
+      });
+
+      const logoutRequest = {
+        refreshToken: 'kakao-refresh-token'
+      };
+
+      const result = await kakaoProvider.logout(logoutRequest);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Kakao 로그아웃이 성공했습니다.');
+      }
+    });
+  });
+
+  describe('refreshToken', () => {
+    it('토큰 갱신 요청을 정상 처리해야 한다', async () => {
+      const { refreshTokenByKakao } = await import('../../src/network');
+      vi.mocked(refreshTokenByKakao).mockResolvedValue({
+        success: true,
+        message: 'Kakao 토큰 갱신이 성공했습니다.',
+        data: {
+          accessToken: 'new-kakao-access-token',
+          refreshToken: 'new-kakao-refresh-token',
+          expiredAt: Date.now() + 3600000
+        }
+      });
+
+      const refreshRequest = {
+        refreshToken: 'kakao-refresh-token'
+      };
+
+      const result = await kakaoProvider.refreshToken(refreshRequest);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Kakao 토큰 갱신이 성공했습니다.');
+        expect(result.data.accessToken).toBe('new-kakao-access-token');
+      }
+    });
+  });
+});

--- a/test/unit/naver-auth-provider.test.ts
+++ b/test/unit/naver-auth-provider.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NaverAuthProvider } from '../../src/providers/implementations/NaverAuthProvider';
+import { NaverAuthProviderConfig } from '../../src/providers/interfaces/config/auth-config';
+import { FakeHttpClient } from '../mocks/FakeHttpClient';
+import { Token } from '../../src/shared/types';
+
+// Naver Auth API 모킹
+vi.mock('../../src/network/naverAuthApi', () => ({
+  validateTokenByNaver: vi.fn(),
+  getUserInfoByNaver: vi.fn(),
+  checkNaverServiceAvailability: vi.fn()
+}));
+
+// Network 모듈 모킹 (loginByNaver, logoutByNaver, refreshTokenByNaver가 여기서 export됨)
+vi.mock('../../src/network', () => ({
+  loginByNaver: vi.fn(),
+  logoutByNaver: vi.fn(),
+  refreshTokenByNaver: vi.fn()
+}));
+
+describe('NaverAuthProvider', () => {
+  let naverProvider: NaverAuthProvider;
+  let mockHttpClient: FakeHttpClient;
+  let mockApiConfig: any;
+  let mockConfig: NaverAuthProviderConfig;
+
+  beforeEach(() => {
+    mockHttpClient = new FakeHttpClient();
+    mockApiConfig = {
+      apiBaseUrl: 'https://api.example.com',
+      endpoints: {
+        naverLogin: '/auth/naver/login',
+        naverLogout: '/auth/naver/logout',
+        naverRefresh: '/auth/naver/refresh',
+        health: '/health' // Added health endpoint for isAvailable test
+      }
+    };
+    mockConfig = {
+      naverClientId: 'test-naver-client-id',
+      timeout: 10000,
+      retryCount: 3
+    };
+
+    naverProvider = new NaverAuthProvider(mockConfig, mockHttpClient, mockApiConfig);
+  });
+
+  describe('validateToken', () => {
+    it('액세스 토큰이 없으면 에러를 반환해야 한다', async () => {
+      const { validateTokenByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(validateTokenByNaver).mockResolvedValue({
+        success: false,
+        error: '토큰 검증을 위해 액세스 토큰이 필요합니다.',
+        message: '액세스 토큰이 필요합니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: '',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await naverProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('토큰 검증을 위해 액세스 토큰이 필요합니다.');
+        expect(result.message).toBe('액세스 토큰이 필요합니다.');
+      }
+    });
+
+    it('액세스 토큰이 null이면 에러를 반환해야 한다', async () => {
+      const { validateTokenByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(validateTokenByNaver).mockResolvedValue({
+        success: false,
+        error: '토큰 검증을 위해 액세스 토큰이 필요합니다.',
+        message: '액세스 토큰이 필요합니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: null as any,
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await naverProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('토큰 검증을 위해 액세스 토큰이 필요합니다.');
+      }
+    });
+
+    it('Naver 토큰 검증이 실패하면 에러를 반환해야 한다', async () => {
+      const { validateTokenByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(validateTokenByNaver).mockResolvedValue({
+        success: false,
+        error: '제공된 토큰이 유효하지 않거나 만료되었습니다.',
+        message: 'Naver 토큰 검증에 실패했습니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await naverProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('제공된 토큰이 유효하지 않거나 만료되었습니다.');
+        expect(result.message).toBe('Naver 토큰 검증에 실패했습니다.');
+      }
+    });
+
+    it('이메일이 인증되지 않았으면 에러를 반환해야 한다', async () => {
+      const { validateTokenByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(validateTokenByNaver).mockResolvedValue({
+        success: false,
+        error: 'Naver 계정의 이메일 인증이 필요합니다.',
+        message: '이메일이 인증되지 않았습니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await naverProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('Naver 계정의 이메일 인증이 필요합니다.');
+        expect(result.message).toBe('이메일이 인증되지 않았습니다.');
+      }
+    });
+
+    it('토큰 검증이 성공하면 성공 응답을 반환해야 한다', async () => {
+      const { validateTokenByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(validateTokenByNaver).mockResolvedValue({
+        success: true,
+        message: 'Naver 토큰 검증이 성공했습니다.',
+        data: true
+      });
+
+      const token: Token = {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await naverProvider.validateToken(token);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Naver 토큰 검증이 성공했습니다.');
+        expect(result.data).toBe(true); // TokenValidationResponse는 boolean을 반환
+      }
+    });
+
+    it('예외가 발생하면 에러 응답을 반환해야 한다', async () => {
+      const { validateTokenByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(validateTokenByNaver).mockResolvedValue({
+        success: false,
+        error: '토큰 검증 과정에서 예상치 못한 오류가 발생했습니다.',
+        message: 'Naver 토큰 검증 중 오류가 발생했습니다.',
+        data: null
+      });
+
+      const token: Token = {
+        accessToken: 'valid-access-token',
+        refreshToken: 'refresh-token',
+        expiredAt: Date.now() + 3600000
+      };
+
+      const result = await naverProvider.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('토큰 검증 과정에서 예상치 못한 오류가 발생했습니다.');
+        expect(result.message).toBe('Naver 토큰 검증 중 오류가 발생했습니다.');
+      }
+    });
+  });
+
+  describe('getUserInfo', () => {
+    it('액세스 토큰이 없으면 에러를 반환해야 한다', async () => {
+      const { getUserInfoByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(getUserInfoByNaver).mockResolvedValue({
+        success: false,
+        error: '사용자 정보 조회를 위해 액세스 토큰이 필요합니다.',
+        message: '액세스 토큰이 필요합니다.',
+        data: null
+      });
+
+      const token: Token = { accessToken: '', refreshToken: 'r', expiredAt: Date.now() + 1000 };
+      const result = await naverProvider.getUserInfo(token);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('사용자 정보 조회를 위해 액세스 토큰이 필요합니다.');
+        expect(result.message).toBe('액세스 토큰이 필요합니다.');
+      }
+    });
+
+    it('토큰이 유효하지 않으면 에러를 반환해야 한다', async () => {
+      const { getUserInfoByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(getUserInfoByNaver).mockResolvedValue({
+        success: false,
+        error: '제공된 토큰이 유효하지 않거나 만료되었습니다.',
+        message: 'Naver 사용자 정보 조회에 실패했습니다.',
+        data: null
+      });
+      const token: Token = { accessToken: 'x', refreshToken: 'r', expiredAt: Date.now() + 1000 };
+      const result = await naverProvider.getUserInfo(token);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('제공된 토큰이 유효하지 않거나 만료되었습니다.');
+        expect(result.message).toBe('Naver 사용자 정보 조회에 실패했습니다.');
+      }
+    });
+
+    it('이메일이 인증되지 않으면 에러를 반환해야 한다', async () => {
+      const { getUserInfoByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(getUserInfoByNaver).mockResolvedValue({
+        success: false,
+        error: 'Naver 계정의 이메일 인증이 필요합니다.',
+        message: '이메일이 인증되지 않았습니다.',
+        data: null
+      });
+      const token: Token = { accessToken: 'x', refreshToken: 'r', expiredAt: Date.now() + 1000 };
+      const result = await naverProvider.getUserInfo(token);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('Naver 계정의 이메일 인증이 필요합니다.');
+        expect(result.message).toBe('이메일이 인증되지 않았습니다.');
+      }
+    });
+
+    it('정상 조회 시 사용자 정보를 반환해야 한다', async () => {
+      const { getUserInfoByNaver } = await import('../../src/network/naverAuthApi');
+      vi.mocked(getUserInfoByNaver).mockResolvedValue({
+        success: true,
+        message: 'Naver 사용자 정보 조회가 성공했습니다.',
+        data: { id: 'u1', email: 'a@b.com', nickname: 'A', provider: 'naver' }
+      });
+      const token: Token = { accessToken: 'x', refreshToken: 'r', expiredAt: Date.now() + 1000 };
+      const result = await naverProvider.getUserInfo(token);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Naver 사용자 정보 조회가 성공했습니다.');
+        expect(result.data).toEqual({ id: 'u1', email: 'a@b.com', nickname: 'A', provider: 'naver' });
+      }
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('헬스 체크가 성공하면 true를 반환해야 한다', async () => {
+      const { checkNaverServiceAvailability } = await import('../../src/network/naverAuthApi');
+      vi.mocked(checkNaverServiceAvailability).mockResolvedValue({
+        success: true,
+        message: 'Naver 서비스가 정상입니다.',
+        data: true
+      });
+
+      const result = await naverProvider.isAvailable();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(true);
+      }
+    });
+
+    it('헬스 체크가 실패하면 에러를 반환해야 한다', async () => {
+      const { checkNaverServiceAvailability } = await import('../../src/network/naverAuthApi');
+      vi.mocked(checkNaverServiceAvailability).mockResolvedValue({
+        success: false,
+        error: 'Naver 서비스가 사용 불가능합니다.',
+        message: '서비스 점검 중입니다.',
+        data: null
+      });
+
+      const result = await naverProvider.isAvailable();
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('login', () => {
+    it('OAuth 로그인 요청이 아니면 에러를 반환해야 한다', async () => {
+      // Email 로그인 요청 형태로 테스트
+      const invalidRequest = {
+        email: 'test@example.com',
+        password: 'password123'
+      } as any;
+
+      const result = await naverProvider.login(invalidRequest);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('NaverAuthProvider는 OAuth 로그인 요청만 지원합니다.');
+        expect(result.message).toBe('OAuth 로그인 요청이 아닙니다.');
+      }
+    });
+
+    it('authCode가 있는 OAuth 요청은 정상 처리해야 한다', async () => {
+      const { loginByNaver } = await import('../../src/network');
+      vi.mocked(loginByNaver).mockResolvedValue({
+        success: true,
+        message: 'Naver 로그인이 성공했습니다.',
+        data: {
+          token: {
+            accessToken: 'naver-access-token',
+            refreshToken: 'naver-refresh-token',
+            expiredAt: Date.now() + 3600000
+          },
+          user: {
+            id: 'naver-user-1',
+            email: 'test@naver.com',
+            nickname: 'Naver User',
+            provider: 'naver'
+          }
+        }
+      });
+
+      const oauthRequest = {
+        authCode: 'naver-auth-code-123',
+        codeVerifier: 'code-verifier'
+      };
+
+      const result = await naverProvider.login(oauthRequest);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Naver 로그인이 성공했습니다.');
+        expect(result.data.user.provider).toBe('naver');
+      }
+    });
+  });
+
+  describe('logout', () => {
+    it('로그아웃 요청을 정상 처리해야 한다', async () => {
+      const { logoutByNaver } = await import('../../src/network');
+      vi.mocked(logoutByNaver).mockResolvedValue({
+        success: true,
+        message: 'Naver 로그아웃이 성공했습니다.',
+        data: null
+      });
+
+      const logoutRequest = {
+        refreshToken: 'naver-refresh-token'
+      };
+
+      const result = await naverProvider.logout(logoutRequest);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Naver 로그아웃이 성공했습니다.');
+      }
+    });
+  });
+
+  describe('refreshToken', () => {
+    it('토큰 갱신 요청을 정상 처리해야 한다', async () => {
+      const { refreshTokenByNaver } = await import('../../src/network');
+      vi.mocked(refreshTokenByNaver).mockResolvedValue({
+        success: true,
+        message: 'Naver 토큰 갱신이 성공했습니다.',
+        data: {
+          accessToken: 'new-naver-access-token',
+          refreshToken: 'new-naver-refresh-token',
+          expiredAt: Date.now() + 3600000
+        }
+      });
+
+      const refreshRequest = {
+        refreshToken: 'naver-refresh-token'
+      };
+
+      const result = await naverProvider.refreshToken(refreshRequest);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toBe('Naver 토큰 갱신이 성공했습니다.');
+        expect(result.data.accessToken).toBe('new-naver-access-token');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close [WQ-143]


## 📝 작업 내용

네이버와 카카오 OAuth 로그인 기능을 auth-core 라이브러리에 추가했습니다. 기존 Google OAuth와 동일한 패턴으로 구현했습니다.

1.  인증 제공자 추가
- `KakaoAuthProvider`, `NaverAuthProvider`
2. 네트워크 레이어 확장
- `kakaoAuthApi.ts`, `naverAuthApi.ts`
- 플랫폼별 처리 지원 (웹/모바일/앱)
3. 설정 및 타입 확장
- `KakaoAuthProviderConfig`, `NaverAuthProviderConfig`
- AuthProviderType에 'kakao', 'naver' 추가
- API 엔드포인트에 카카오/네이버 관련 경로 추가
4. 테스트 커버리지
- 단위 테스트: KakaoAuthProvider, NaverAuthProvider 각각 포괄적 테스트
- 통합 테스트: React Native 환경에서의 OAuth 플로우 테스트
## 📷 스크린샷

> 이미지


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭


### 📌 PR 진행 시 참고사항

- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)

[WQ-143]: https://growgrammers.atlassian.net/browse/WQ-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ